### PR TITLE
Add an iMMERSE Launchpad motion-vector bridge, and document the D3D9 depth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ game frame → ReShade effects → [motion vectors] → [DLSS5_Feed] → DLSS5-F
 - [Install for a 32-bit game](#install-for-a-32-bit-game-beta)
 - [Install for a DirectX 9 game](#install-for-a-directx-9-game-beta)
 - [Install for a Vulkan game](#install-for-a-vulkan-game)
+- [Motion vector providers](#motion-vector-providers)
+  - [iMMERSE Launchpad, through a bridge](#immerse-launchpad-through-a-bridge)
 - [How it works](#how-it-works)
   - [The 32-bit path](#the-32-bit-path)
   - [The DirectX 9 path](#the-directx-9-path)
@@ -163,7 +165,24 @@ game already wraps to D3D11 — skip this section, it is just a normal 32-bit in
    [Install for a 32-bit game](#install-for-a-32-bit-game-beta) (or the 64-bit steps for a 64-bit
    D3D9 game). ReShade must be installed as **`dxgi.dll`**, never as `d3d9.dll` — dgVoodoo owns that
    filename now and the two would fight.
-6. Turn the watermark off once everything works.
+6. **Fix the depth buffer.** A translated D3D9 game will usually hand ReShade an *empty* depth
+   buffer even though Generic Depth lists a candidate, and DLSS then runs with no depth at all. Two
+   settings, neither of which the other install paths need:
+
+   * **`RESHADE_DEPTH_INPUT_IS_REVERSED=0`** in ReShade's global preprocessor definitions (Home tab
+     ▸ *Edit global preprocessor definitions*). ReShade defaults it to `1`, which is correct for
+     modern reversed-Z engines and wrong for everything of the D3D9 era. The feeder's
+     `depth_inverted` follows this definition by default; `depth_inverted=0` in `dlss5-feed.cfg`
+     forces it independently of the shaders.
+   * **`DepthCopyBeforeClears=1`** in the `[DEPTH]` section of `reshade.ini` (Add-ons ▸ *Generic
+     Depth* in the overlay). Engines of that age clear depth several times per frame — scene,
+     cutscene layers, UI — and by default ReShade takes the buffer at the end of the frame, when it
+     has already been wiped. Then step **`DepthCopyAtClearIndex`** through `0, 1, 2, …` until depth
+     appears.
+
+   Verify with **DLSS 5 Feed – debug view ▸ Raw depth**: a flat white or black screen means no depth
+   is arriving; you want visible near/far shading and object silhouettes.
+7. Turn the watermark off once everything works.
 
 ## Install for a Vulkan game
 
@@ -195,6 +214,52 @@ layer\run-with-feed-layer.bat "E:\path\to\game.exe"
 ```
 
 See [`layer/README.md`](layer/README.md). It does the same job from outside the process.
+
+## Motion vector providers
+
+DLSS5-Feeder consumes exactly one interface: the shared `texMotionVectors` texture (RG16F, full
+resolution, delta UV with `prev_uv = uv + mv`). Enable **one** provider that writes it, above
+`DLSS 5 Feed` in the effect list:
+
+* **[ReshadeMotionEstimation](https://github.com/JakobPCoder/ReshadeMotionEstimation)** (technique
+  `DRME`, CC BY-NC 4.0) — the straightforward choice, writes `texMotionVectors` directly.
+* **`qUINT_motionvectors`** — same convention, also direct.
+* **iMMERSE Launchpad** — better optical flow, but needs a bridge; see below.
+
+> The feed log line `MV provider <name>` reports that `texMotionVectors` **exists**, not that
+> anything is writing to it. Zero-filled vectors look exactly the same in the log. To check the
+> actual contents, enable the **DLSS 5 Feed – debug view** technique: a static scene must be flat
+> grey and moving the camera must flood the frame with colour that tracks the direction.
+
+### iMMERSE Launchpad, through a bridge
+
+Launchpad has the most accurate free optical flow for ReShade, but it is **not** a drop-in provider.
+Two independent reasons, both of which fail silently:
+
+1. **It publishes its vectors as `Deferred::MotionVectorsTex`**, not `texMotionVectors`. That
+   texture lives inside a namespace, and ReShade mangles names in namespaces — so a plain top-level
+   declaration of `MotionVectorsTex` creates a *different* resource and binds to nothing.
+2. **It computes optical flow only on request.** Its flow vertex shader culls the geometry when the
+   feature was not requested, and it clears the request buffer at the end of its own technique,
+   explicitly so that effects running after it can ask for what they need. Nothing in a stock setup
+   asks, so the flow passes never run and the texture stays zero.
+
+**`shaders/DLSS5_MV_Bridge.fx`** handles both: it declares the provider-side resources so ReShade
+binds Launchpad's actual textures, raises the optical-flow request, and copies the vectors into
+`texMotionVectors` unchanged — the conventions already agree, so there is no rescaling. Like the
+rest of this project it includes no third-party files and contains no third-party code; interop is
+by declaration only.
+
+1. Install **iMMERSE** (`MartysMods_LAUNCHPAD.fx` plus its `MartysMods\` headers) and its textures
+   from **https://github.com/martymcmodding/iMMERSE** into `reshade-shaders\`.
+2. Put **`DLSS5_MV_Bridge.fx`** in `reshade-shaders\Shaders\`.
+3. Enable, in this order: **Launchpad** → **DLSS 5 MV Bridge** → **DLSS 5 Feed**. Disable DRME and
+   any other provider — they write the same texture.
+
+The request reaches Launchpad on the next frame, so the very first frame after enabling has no
+vectors yet. A useful side check: with the bridge working, the flow passes actually execute, so the
+frame cost visibly rises — if enabling it changes nothing at all, the request is not getting
+through.
 
 ## How it works
 
@@ -284,8 +349,8 @@ down. The hook is removed on DLL unload, since ReShade reloads add-ons per Vulka
 | D3D11, D3D12 or Vulkan game, 32- or 64-bit | NGX is 64-bit only, hence the helper process for 32-bit games. D3D9 works through [dgVoodoo2](#install-for-a-directx-9-game-beta); Vulkan works out of the box (the add-on adds the interop extensions itself; [a small bundled layer](#install-for-a-vulkan-game) is the fallback). D3D10 is not supported. |
 | ReShade 6.8+ **with add-on support** | Generic Depth add-on enabled and picking the scene depth. |
 | DLSS 5 neural-rendering add-on (`renodx-dlss5.addon64`) + `nvngx_dlssnr.dll` | from its own author; this project does not include it. |
-| `nvngx_dlss.dll` | a DLSS Super Resolution runtime next to the game (the driver's copy is used otherwise). |
-| A motion vector provider | any shader writing the community-standard `texMotionVectors`, e.g. **ReshadeMotionEstimation** (CC BY-NC 4.0) or **qUINT_motionvectors**. Install it yourself — nothing third-party is bundled, and our shader includes no third-party files. |
+| `nvngx_dlss.dll` | a DLSS Super Resolution runtime next to the game (the driver's copy is used otherwise). **It must carry NVIDIA's own signature.** Some games ship a copy re-signed by their publisher; NGX rejects those and the host log then says `SuperSampling.Available=0` with no further explanation. Check with `Get-AuthenticodeSignature` — the signer has to be `CN=NVIDIA Corporation`. |
+| A motion vector provider | any shader writing the community-standard `texMotionVectors`, e.g. **ReshadeMotionEstimation** (CC BY-NC 4.0) or **qUINT_motionvectors**. Install it yourself — nothing third-party is bundled, and our shaders include no third-party files. **iMMERSE Launchpad does not write `texMotionVectors`** and is not a drop-in provider; see [Motion vector providers](#motion-vector-providers). |
 | `dlss5-feed.addon64` (or `.addon32` + `host64\`) + `DLSS5_Feed.fx` | this project. |
 
 ## Configuration
@@ -344,6 +409,16 @@ Common cases:
 * **Image is static-sharp but smears when moving** — no provider is writing `texMotionVectors`
   (the feed log then says "no known texMotionVectors provider found"): enable DRME (or another
   provider) above DLSS 5 Feed.
+* **`Raw depth` in the debug view is a flat white or black screen** — no depth is reaching the
+  shaders, even if Generic Depth lists a candidate buffer. Most common on games translated from
+  D3D9; see the depth step in [the D3D9 section](#install-for-a-directx-9-game-beta)
+  (`DepthCopyBeforeClears`, `DepthCopyAtClearIndex`, `RESHADE_DEPTH_INPUT_IS_REVERSED`).
+* **The host logs `SuperSampling.Available=0` and `NGX unavailable`, then exits** — `nvngx_dlss.dll`
+  is there but NGX refused it. Usually a copy re-signed by a game's publisher rather than NVIDIA;
+  check the signer and swap in an NVIDIA-signed runtime.
+* **The feed log says `MV provider <name>` but motion still smears** — that line only reports that
+  `texMotionVectors` exists, not that anything writes to it. Confirm the contents with the debug
+  view; for iMMERSE Launchpad see [Motion vector providers](#motion-vector-providers).
 * **Nothing happens, no `dlss5-feed.log`** — ReShade's architecture does not match the game's
   (a 64-bit `dxgi.dll` cannot load into a 32-bit game, and vice versa).
 * **"ran out of video memory" with dgVoodoo** — raise `VRAM` in `dgVoodoo.conf`; the default 256 MB

--- a/shaders/DLSS5_MV_Bridge.fx
+++ b/shaders/DLSS5_MV_Bridge.fx
@@ -1,0 +1,178 @@
+/*
+    DLSS5_MV_Bridge.fx
+
+    Bridges iMMERSE Launchpad's motion vectors into the community-standard
+    texMotionVectors that DLSS5_Feed reads.
+
+    WHY THIS IS NEEDED
+    ------------------
+    DLSS5_Feed consumes exactly one interface: the shared texMotionVectors
+    texture. Launchpad does not write it -- it publishes its vectors as
+    Deferred::MotionVectorsTex instead. So Launchpad, despite being the most
+    accurate free optical-flow provider for ReShade, is not a drop-in provider
+    for the feeder. Two separate reasons, both silent:
+
+    1) NAMESPACE. Launchpad's texture lives in "namespace Deferred". ReShade
+       mangles names inside namespaces, so a plain top-level declaration of
+       "texture MotionVectorsTex" creates a DIFFERENT resource and binds to
+       nothing. The declaration has to be namespaced identically.
+
+    2) PREDICATION. Launchpad computes optical flow only on demand. Its flow
+       vertex shader culls the geometry when the feature was not requested:
+
+           if(!Deferred::IPC::is_requested(MARTYSMODS_IPC_FEATURE_OPTICALFLOW))
+               o.vpos.xy = -100000;
+
+       Launchpad ends its own technique with IPC_CLEAR(), explicitly so that
+       effects running after it can request what they need. Nothing in the
+       stock setup does that, so the flow passes never run and the texture
+       stays zero. A consumer MUST raise the request itself.
+
+       The request is picked up by Launchpad on the NEXT frame, so in steady
+       state the flow is computed every frame.
+
+    NO THIRD-PARTY FILES ARE INCLUDED
+    ---------------------------------
+    In keeping with this project's stated principle, this shader includes no
+    iMMERSE (or any other provider's) files and contains no third-party code.
+    Interop is by declaration only -- the same mechanism that makes the
+    texMotionVectors convention work: ReShade binds the same resource when a
+    texture is declared with a matching qualified name and matching properties.
+
+    The predication buffer is a 1x1 RGBA8 flag, one channel per feature
+    (1 = normals, 2 = albedo, 4 = optical flow), written with a single point
+    primitive and a render target write mask. The helper shaders below return
+    constants -- that is the wire protocol, not borrowed code.
+
+    Vector conventions already agree, so the copy is 1:1: both sides use
+    delta UV with prev_uv = uv + mv, both are RG16F at BUFFER_WIDTH x
+    BUFFER_HEIGHT. No rescaling is applied.
+
+    USAGE
+    -----
+    Effect order:   Launchpad  ->  DLSS5_MV_Bridge  ->  DLSS 5 Feed
+    Disable any other motion-vector provider (DRME, qUINT) while this is on --
+    they write the same texMotionVectors.
+
+    Verify with the "DLSS 5 Feed - debug view" technique: a static scene must
+    be flat grey, and moving the camera must flood the frame with colour that
+    tracks the direction. Note that the feeder log reports the PRESENCE of
+    texMotionVectors, not its contents, so the log alone cannot tell you
+    whether vectors are live.
+*/
+
+//=============================================================================
+// Provider-side resources, declared to match iMMERSE Launchpad
+//=============================================================================
+
+namespace Deferred
+{
+    // Matches mmx_deferred.fxh: delta UV, RG16F, full resolution.
+    texture MotionVectorsTex { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F; };
+    sampler sBridgeMotionVectors { Texture = MotionVectorsTex; };
+
+    namespace IPC
+    {
+        // Matches mmx_deferred.fxh: no dimensions given, so this is 1x1 RGBA8.
+        // One channel per requestable feature; optical flow is channel 3 (mask 4).
+        texture2D PredicationBuffer { Format = RGBA8; };
+    }
+}
+
+#define BRIDGE_IPC_FEATURE_OPTICALFLOW 4
+
+//=============================================================================
+// Consumer-side target, declared to match DLSS5_Feed.fx
+//=============================================================================
+
+texture texMotionVectors < pooled = false; > { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F; };
+
+//=============================================================================
+// UI
+//=============================================================================
+
+uniform float2 BRIDGE_SIGN <
+    ui_type = "drag";
+    ui_min = -1.0; ui_max = 1.0; ui_step = 2.0;
+    ui_label = "Motion vector sign (x, y)";
+    ui_tooltip = "Flip a component if the output doubles or smears in that\n"
+                 "direction. Both sides use the same convention, so 1, 1 is\n"
+                 "normally correct.";
+> = float2(1.0, 1.0);
+
+uniform float BRIDGE_SCALE <
+    ui_type = "drag";
+    ui_min = 0.0; ui_max = 4.0; ui_step = 0.05;
+    ui_label = "Motion vector scale";
+    ui_tooltip = "1.0 = the provider's estimate as-is. Diagnostic only.";
+> = 1.0;
+
+//=============================================================================
+// Shaders
+//=============================================================================
+
+struct BridgeVSOUT
+{
+    float4 vpos : SV_Position;
+    float2 uv   : TEXCOORD0;
+};
+
+// Fullscreen triangle. Written here so the shader pulls in no headers at all;
+// BUFFER_WIDTH / BUFFER_HEIGHT are ReShade built-ins.
+BridgeVSOUT BridgeVS(in uint id : SV_VertexID)
+{
+    BridgeVSOUT o;
+    o.uv.x = (id == 2) ? 2.0 : 0.0;
+    o.uv.y = (id == 1) ? 2.0 : 0.0;
+    o.vpos = float4(o.uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+    return o;
+}
+
+float4 BridgeCopyPS(in BridgeVSOUT i) : SV_Target0
+{
+    float2 mv = tex2Dlod(Deferred::sBridgeMotionVectors, float4(i.uv, 0.0, 0.0)).xy;
+    return float4(mv * BRIDGE_SIGN * BRIDGE_SCALE, 0.0, 0.0);
+}
+
+// Single point covering the 1x1 predication buffer.
+float4 BridgeRequestVS(in uint id : SV_VertexID) : SV_Position
+{
+    return float4(0.0, 0.0, 0.0, 1.0);
+}
+
+float4 BridgeRequestPS(in float4 vpos : SV_Position) : SV_Target0
+{
+    return 1.0;
+}
+
+//=============================================================================
+
+technique DLSS5_MV_Bridge
+<
+    ui_label   = "DLSS 5 MV Bridge (iMMERSE Launchpad -> texMotionVectors)";
+    ui_tooltip = "Place BETWEEN Launchpad and DLSS 5 Feed, and disable any\n"
+                 "other motion-vector provider.\n\n"
+                 "Also raises Launchpad's optical-flow request, without which\n"
+                 "it does not compute flow at all.";
+>
+{
+    pass Copy
+    {
+        VertexShader = BridgeVS;
+        PixelShader  = BridgeCopyPS;
+        RenderTarget = texMotionVectors;
+    }
+
+    // Request optical flow for the next frame. Launchpad clears the
+    // predication buffer at the end of its own technique, so this has to run
+    // after it -- which the required effect order already guarantees.
+    pass RequestOpticalFlow
+    {
+        PrimitiveTopology    = POINTLIST;
+        VertexCount          = 1;
+        VertexShader         = BridgeRequestVS;
+        PixelShader          = BridgeRequestPS;
+        RenderTarget         = Deferred::IPC::PredicationBuffer;
+        RenderTargetWriteMask = BRIDGE_IPC_FEATURE_OPTICALFLOW;
+    }
+}


### PR DESCRIPTION
Brought the feeder up on **Bully: Scholarship Edition** — 32-bit, Gamebryo, 2008, real D3D9 through dgVoodoo2 — and it works: `feature 18 created`, `inline feature 18 evaluation succeeded`, stable 60 fps with the feed at 2 % of the frame. Getting there turned up one missing piece of code and four things the README does not mention yet. This PR adds both.

Happy to split this into two PRs (shader / docs) if you would rather review them separately.

---

## 1. `shaders/DLSS5_MV_Bridge.fx` — makes iMMERSE Launchpad usable as a provider

The README's opening line mentions "LaunchPad motion vectors", and Launchpad has the most accurate free optical flow for ReShade — but it is **not** a drop-in provider. Two independent reasons, and both fail completely silently:

**It does not write `texMotionVectors`.** It publishes its vectors as `Deferred::MotionVectorsTex`. Since that lives inside a namespace and ReShade mangles names in namespaces, a plain top-level declaration of `MotionVectorsTex` creates a *different* resource and binds to nothing.

**It computes optical flow only on request.** Its flow vertex shader culls the geometry when the feature was not requested:

```hlsl
if(!Deferred::IPC::is_requested(MARTYSMODS_IPC_FEATURE_OPTICALFLOW)) o.vpos.xy = -100000;
```

and it ends its own technique with `IPC_CLEAR()`, with the author's comment saying it clears there *"such that any pass or shader following afterwards may request a feature"*. Nothing in a stock setup asks, so the flow passes never run and the texture stays zero for as long as you care to look at it.

The bridge declares the provider-side resources so ReShade binds Launchpad's actual textures, raises the optical-flow request, and copies the vectors into `texMotionVectors` unchanged. No rescaling: both sides are delta UV with `prev_uv = uv + mv`, RG16F at buffer resolution — verified against `tex2Dlod(sLinearDepthPrevLo, i.uv + res.xy, 0)` in Launchpad's own source.

**No third-party files, no third-party code**, in keeping with what `DLSS5_Feed.fx` and the Credits section both state. Interop is by declaration only — the same mechanism the `texMotionVectors` convention already relies on. The predication buffer turns out to be a 1×1 RGBA8 flag, one channel per feature, written with a single point primitive and a render target write mask; the two helper shaders return `float4(0,0,0,1)` and `1`. That is the wire protocol, not borrowed code.

Usage is `Launchpad → DLSS 5 MV Bridge → DLSS 5 Feed`, with other providers disabled. The request lands one frame later, so the first frame after enabling has no vectors — noted in the file header and the README.

## 2. README: what a D3D9 setup needs after the D3D11 runtime exists

The existing D3D9 section gets you a real D3D11 runtime, and stops there. Everything below is what stood between that point and a working contract.

**The depth buffer arrives empty.** Generic Depth listed a candidate, and `Raw depth` in the debug view was still a flat white screen. Engines of that era clear depth several times per frame — scene, cutscene layers, UI — and ReShade by default takes the buffer at the end of the frame, when it has already been wiped. `DepthCopyBeforeClears=1` plus stepping `DepthCopyAtClearIndex` fixed it.

**`RESHADE_DEPTH_INPUT_IS_REVERSED` must be 0.** ReShade defaults it to `1`, which is right for modern reversed-Z engines and wrong for anything of this vintage. With the default, DLSS gets inverted depth and its disocclusion logic is working from garbage. Worth stating explicitly in a section that exists specifically for old games.

**`nvngx_dlss.dll` must be signed by NVIDIA.** The README says to take one from any DLSS game; if that copy was re-signed by the publisher, NGX rejects it and the only symptom is `SuperSampling.Available=0` followed by `NGX unavailable`. Ours came from a game signed `CN=Facepunch Studios Ltd` and cost a debugging cycle before the signature check explained it.

**`MV provider <name>` in the log is not evidence.** It reports that `texMotionVectors` exists, not that anything writes to it. Zero-filled vectors produce an identical log line. Both our depth and our motion vectors were dead for a long stretch while every log looked healthy — the debug view is the only real confirmation, so the README now says so next to the provider list and in troubleshooting.

## Testing

* RTX 5080 Laptop, driver 610.88, Windows 11 26200
* Bully: Scholarship Edition, 32-bit D3D9 → dgVoodoo2 2.87.3 (`d3d11_fl11_0`) → ReShade 6.8.0 x86 as `dxgi.dll` → `dlss5-feed.addon32` v0.5.0 → `host64\` → DLSSNR 310.8
* Bridge compiles in 0.003 s with no warnings; `Raw depth` and `Motion vectors` debug views both confirmed live, colour tracking direction
* ~32 400 frames over one session with no crash; `feature ready: 2560x1600 DLAA`, `inline feature 18 evaluation succeeded (count=…)` climbing
* Cross-checked against DRME on the same setup — both provide vectors, Launchpad without the visible block structure

One incidental data point, since the README's own note says exclusive fullscreen can churn the swapchain: forcing a higher internal resolution in dgVoodoo (`Resolution = h:3840, v:2400`) keeps the swapchain at display size, so DLAA still runs at output resolution and the extra samples are free supersampling ahead of it. Selecting an oversized mode *in the game* instead makes the swapchain oversized and blew past dgVoodoo's virtual VRAM. Not documented here since it is dgVoodoo-side rather than feeder-side, but happy to add it if you think it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4oiBmHTDr7WNrizq4FQmD
