### PR TITLE
Validate motion and depth guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Proven working in seven games covering every supported path:
 | Game | Bitness / API | Result |
 | --- | --- | --- |
 | **Metro 2033 Redux** | 64-bit D3D11 | 4K DLAA + NR, HDR backbuffer |
+| **Subnautica** | 64-bit D3D11 | Contributor-verified: 4K DLAA + NR, Generic Depth clear-selection profile |
 | **The Lord of the Rings: War in the North – Legacy Edition** | 64-bit D3D12 | 4K, same-device path, 120 fps |
 | **Splinter Cell: Blacklist** | 32-bit D3D11 | 60 fps, cross-process host |
 | **BioShock Remastered** | 32-bit D3D11 (D3D9→D3D11 wrapper) | 4K, Luma HDR |
@@ -119,6 +120,10 @@ in fast motion, softness on thin moving geometry), and the HUD is processed alon
 2. Download **`dlss5-feed.addon64`** and **`DLSS5_Feed.fx`** from the
    **[latest release](https://github.com/jlrouzies-fr/DLSS5-Feeder/releases/latest)**. Put
    `dlss5-feed.addon64` next to the game `.exe`, and `DLSS5_Feed.fx` into `reshade-shaders\Shaders\`.
+   The shader includes the standard **`ReShade.fxh`** header. ReShade normally installs it with its
+   standard shader package; if `ReShade.log` says it cannot open that file, copy `ReShade.fxh` from
+   the official [reshade-shaders](https://github.com/crosire/reshade-shaders/tree/slim/Shaders)
+   repository into the same `Shaders\` folder.
 3. Download **[LumeniteFX](https://github.com/umar-afzaal/LumeniteFX)** (Code ▸ Download ZIP). Copy
    its `Shaders\` folder (the `lumenite_*.fx` files and `include\`) into `reshade-shaders\Shaders\`,
    and `Textures\lumenite_bluenoise256.png` into `reshade-shaders\Textures\`.
@@ -255,15 +260,17 @@ Rules that apply to all of them:
 > motion vectors at all. Releases up to 0.5.2 recommended it. This release reads the compiler error
 > out of `ReShade.log` and reports it in the overlay and `dlss5-feed.log`.
 
-### Are the vectors actually arriving?
+### Are the guides actually arriving?
 
-Two independent checks, both new in 0.6.0:
+The add-on checks both configuration and the actual textures handed to DLSS:
 
 * The overlay's **Motion vectors** section states the mode, the provider found, and its state
   (`enabled` / `DISABLED` / `FAILED TO COMPILE` / `not installed`), in red when something is wrong.
-* An **MV probe** reads back the vectors *actually handed to DLSS* every 600 frames and logs their
-  mean/max magnitude and non-zero share: `MV probe … N% non-zero`. While you move, that must not
-  be 0%.
+* A low-frequency **guide probe** reads back the vectors *actually handed to DLSS* every 600 frames
+  and logs their mean/max magnitude and non-zero share: `MV probe … N% non-zero`. While you move,
+  that must not be 0%. The same deferred readback samples four distributed depth blocks and reports
+  min/max/mean/variance/finite share. It warns when sampled depth is flat without disabling the feed.
+  Both readbacks analyse an older, completed copy, so they do not introduce a per-frame GPU stall.
 
 ### Validation and the trust mask
 
@@ -281,7 +288,8 @@ the pixel is flagged in a `DLSS5_Mask` texture the add-on passes to DLSS as its
 * `DLSS5_Feed.fx` (companion effect) converts the selected provider's motion vectors (delta-UV,
   `prev_uv = uv + mv`) into `DLSS5_MV` (RG16F, **pixels**), copies the raw hardware depth with
   ReShade's orientation fixes into `DLSS5_Depth` (R32F), and flags every vector it does not trust
-  in `DLSS5_Mask` (R8).
+  in `DLSS5_Mask` (R8). MV, mask and raw depth are emitted by one MRT guide pass, avoiding a second
+  full-screen depth pass while leaving the depth values sent to DLSS unchanged.
 * `dlss5-feed.addon64` registers with the ReShade add-on API. After the `DLSS5_Feed` technique
   renders, it takes the backbuffer + those textures and runs `NGX_D3D12_EVALUATE_DLSS` in DLAA
   mode (render size = output size, no jitter). The DLSS 5 neural-rendering add-on
@@ -468,7 +476,8 @@ In `DLSS5_Feed.fx`'s own UI (settings that only make sense per-shader, not per-s
   not part of the 3D world, gets camera vectors it should not have.
 * **DLSS 5 Feed – debug view** technique — nine views: the vectors/depth being sent (static scene =
   grey, motion = colour), the provider's confidence map, the validation mask alone and over the
-  image, which test fired, and the three geometry views.
+  image, which test fired, and the three geometry views. The depth view applies a display-only
+  contrast curve so reversed and far-heavy hardware depth is visible; `DLSS5_Depth` itself stays raw.
 
 Preprocessor definitions on the shader (overlay → *Preprocessor definitions* → reload effects):
 
@@ -480,7 +489,7 @@ Preprocessor definitions on the shader (overlay → *Preprocessor definitions* �
 
 | File | Contents |
 | --- | --- |
-| `dlss5-feed.log` | next to the game exe: resolved effect handles, the session, the contract (`feature ready: WxH DLAA, flags=…`), `frame N delivered`, timing every 600 frames, crash breadcrumbs. |
+| `dlss5-feed.log` | next to the game exe: resolved effect handles, the session, the contract (`feature ready: WxH DLAA, flags=…`), `frame N delivered`, timing and guide probes every 600 frames, crash breadcrumbs. |
 | `ReShade.log` | which graphics API ReShade attached to, shader compile errors. |
 | `host64\dlss5-feed-host.log` | 32-bit games: the helper's own session and per-frame state. |
 | `host64\ReShade.log` | 32-bit games: the DLSS 5 add-on's messages (`feature 18 created`, `inline feature 18 evaluation succeeded`). |
@@ -495,6 +504,26 @@ Common cases:
   it is installed but **disabled**, it **failed to compile** (DRME on ReShade 6.8 — use LumeniteFX
   Kernel instead), or a *different* provider is enabled than the one `DLSS5_MV_PROVIDER` selects.
   The `MV probe … 0% non-zero` line in `dlss5-feed.log` confirms it independently.
+* **Depth probe says sampled depth is flat** — open **DLSS 5 Feed – debug view**, select the depth
+  view, and verify that scene geometry is visible. Then use ReShade's **Add-ons → Generic Depth**
+  page to select the draw call/clear that contains the scene rather than UI or an already-cleared
+  buffer. The warning is diagnostic only; it does not guess a different buffer or disable DLSS.
+* **Subnautica: flat or wrong depth** — this 4K D3D11 profile was contributor-verified with DLAA +
+  neural rendering. Merge these values into the matching sections of `ReShade.ini` and keep every
+  unrelated key. In `PreprocessorDefinitions`, append or replace only the four definitions shown
+  below in the existing comma-separated list; do not discard other definitions:
+
+  ```ini
+  [DEPTH]
+  DepthCopyAtClearIndex=1
+  DepthCopyBeforeClears=2
+  DrawStatsHeuristic=0
+  FilterFormat=0
+  UseAspectRatioHeuristics=3
+
+  [GENERAL]
+  PreprocessorDefinitions=RESHADE_DEPTH_LINEARIZATION_FAR_PLANE=1000.0,RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN=1,RESHADE_DEPTH_INPUT_IS_REVERSED=1,RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0
+  ```
 * **Warping / smearing around flames, flickering lights or transparents** — optical flow answers a
   lighting change with a wrong-but-confident vector. Keep validation on (default), try provider
   `3` (LumeniteFX Kernel) rather than Launchpad, and try `preset=5` or `6` in `dlss5-feed.cfg`

--- a/shaders/DLSS5_Feed.fx
+++ b/shaders/DLSS5_Feed.fx
@@ -648,8 +648,33 @@ float4 GeometryDecide(float2 uv, float d, float2 flow)
     return float4(pred, 2.0, GEOM_MASK_REJECTED * saturate((r - agree) / (4.0 * agree)));
 }
 
+float RawDepth(float2 uv)
+{
+    // Raw hardware depth, exactly as the game wrote it -- the same orientation/offset
+    // corrections ReShade.fxh applies in GetLinearizedDepth(), minus the linearisation
+    // (DLSS must receive the raw values; the add-on tells it whether the range is reversed).
+    float2 t = uv;
+#if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
+    t.y = 1.0 - t.y;
+#endif
+    t.x /= RESHADE_DEPTH_INPUT_X_SCALE;
+    t.y /= RESHADE_DEPTH_INPUT_Y_SCALE;
+#if RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET
+    t.x -= RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET * BUFFER_RCP_WIDTH;
+#else
+    t.x -= RESHADE_DEPTH_INPUT_X_OFFSET / 2.000000001;
+#endif
+#if RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET
+    t.y += RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET * BUFFER_RCP_HEIGHT;
+#else
+    t.y += RESHADE_DEPTH_INPUT_Y_OFFSET / 2.000000001;
+#endif
+    return tex2Dlod(ReShade::DepthBuffer, float4(t, 0.0, 0.0)).x;
+}
+
 void PS_MotionVectors(float4 vpos : SV_Position, float2 uv : TEXCOORD,
-                      out float2 mv_out : SV_Target0, out float mask : SV_Target1)
+                      out float2 mv_out : SV_Target0, out float mask : SV_Target1,
+                      out float depth : SV_Target2)
 {
     // Providers hand out "delta UV": previous position = uv + mv. DLSS wants the same
     // direction, in pixels.
@@ -686,30 +711,7 @@ void PS_MotionVectors(float4 vpos : SV_Position, float2 uv : TEXCOORD,
 
     mv_out = mv * float2(BUFFER_WIDTH, BUFFER_HEIGHT) * MV_SIGN * MV_SCALE;
     mask   = distrust * MASK_STRENGTH;
-}
-
-float PS_Depth(float4 vpos : SV_Position, float2 uv : TEXCOORD) : SV_Target
-{
-    // Raw hardware depth, exactly as the game wrote it -- the same orientation/offset
-    // corrections ReShade.fxh applies in GetLinearizedDepth(), minus the linearisation
-    // (DLSS must receive the raw values; the add-on tells it whether the range is reversed).
-    float2 t = uv;
-#if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
-    t.y = 1.0 - t.y;
-#endif
-    t.x /= RESHADE_DEPTH_INPUT_X_SCALE;
-    t.y /= RESHADE_DEPTH_INPUT_Y_SCALE;
-#if RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET
-    t.x -= RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET * BUFFER_RCP_WIDTH;
-#else
-    t.x -= RESHADE_DEPTH_INPUT_X_OFFSET / 2.000000001;
-#endif
-#if RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET
-    t.y += RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET * BUFFER_RCP_HEIGHT;
-#else
-    t.y += RESHADE_DEPTH_INPUT_Y_OFFSET / 2.000000001;
-#endif
-    return tex2Dlod(ReShade::DepthBuffer, float4(t, 0.0, 0.0)).x;
+    depth  = RawDepth(uv);
 }
 
 // End of the technique: this frame becomes next frame's history. The raw provider vector is
@@ -726,8 +728,14 @@ float3 PS_Debug(float4 vpos : SV_Position, float2 uv : TEXCOORD) : SV_Target
 {
     if (DEBUG_VIEW == 1)
     {
-        float d = tex2Dlod(sDLSS5_Depth, float4(uv, 0.0, 0.0)).x;
-        return d.xxx;
+        const float raw_depth = tex2Dlod(sDLSS5_Depth, float4(uv, 0.0, 0.0)).x;
+#if RESHADE_DEPTH_INPUT_IS_REVERSED
+        const float proximity = raw_depth;
+#else
+        const float proximity = 1.0 - raw_depth;
+#endif
+        // Display-only contrast curve: DLSS5_Depth itself remains raw and untouched.
+        return pow(saturate(proximity), 0.125).xxx;
     }
     if (DEBUG_VIEW == 2)
     {
@@ -794,8 +802,7 @@ technique DLSS5_Feed
 {
     pass FitSamples    { VertexShader = PostProcessVS; PixelShader = PS_FitSamples;    RenderTarget0 = DLSS5_FitA; RenderTarget1 = DLSS5_FitB; }
     pass FitSolve      { VertexShader = PostProcessVS; PixelShader = PS_FitSolve;      RenderTarget0 = DLSS5_Cam0; RenderTarget1 = DLSS5_Cam1; RenderTarget2 = DLSS5_Cam2; RenderTarget3 = DLSS5_Cam3; RenderTarget4 = DLSS5_Cam4; RenderTarget5 = DLSS5_Cam5; }
-    pass MotionVectors { VertexShader = PostProcessVS; PixelShader = PS_MotionVectors; RenderTarget0 = DLSS5_MV; RenderTarget1 = DLSS5_Mask; }
-    pass Depth         { VertexShader = PostProcessVS; PixelShader = PS_Depth;         RenderTarget  = DLSS5_Depth; }
+    pass Guides        { VertexShader = PostProcessVS; PixelShader = PS_MotionVectors; RenderTarget0 = DLSS5_MV; RenderTarget1 = DLSS5_Mask; RenderTarget2 = DLSS5_Depth; }
     pass History       { VertexShader = PostProcessVS; PixelShader = PS_StoreHistory;  RenderTarget0 = DLSS5_PrevLuma; RenderTarget1 = DLSS5_PrevDepth; RenderTarget2 = DLSS5_PrevMV; }
     DLSS5_MV_REQUEST_PASS   // Launchpad only: ask it to compute optical flow again next frame
 }

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -42,6 +42,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <cmath>
 #include <string>
 
 #define ImTextureID ImU64   // required by reshade_overlay.hpp before including imgui.h
@@ -820,12 +821,12 @@ static void CloseListGuarded()
 // NGX crashed while recording into our list: it may hold half-written commands, and
 // executing those is what actually takes the game down (the driver faults later on
 // another thread). Close it guarded, throw it away WITHOUT executing, replace it.
-static void MvProbeAbort();   // defined with the motion-vector probe below
+static void GuideProbeAbort();   // defined with the guide probes below
 
 static void AbortCommands()
 {
     if (g.list == nullptr) return;
-    MvProbeAbort();   // a probe copy recorded into this list will never execute
+    GuideProbeAbort();   // probe copies recorded into this list will never execute
     CloseListGuarded();
     SafeRelease(g.list);
     if (g.alloc[g.frame_slot] != nullptr && g.dev12 != nullptr &&
@@ -837,23 +838,32 @@ static void AbortCommands()
 }
 
 // ---------------------------------------------------------------------------
-// Motion-vector probe. Every kMvProbeEvery frames, copy a 64x64 block from the centre of
-// the MV texture DLSS is about to read into a readback buffer, and analyse the PREVIOUS
-// probe's block -- submitted hundreds of frames ago, so the map never stalls the GPU.
-// It answers, in pixels, the question no other signal can: is the selected provider
-// actually delivering vectors, or is DLSS being fed zeros?
+// Guide probes. Every kGuideProbeEvery frames, copy a small MV block and four distributed
+// depth blocks into readback buffers, then analyse them after the fence confirms completion
+// on a later frame, so mapping never waits for the GPU. This verifies actual contents rather
+// than treating a valid texture handle as proof that DLSS receives useful guides.
 // ---------------------------------------------------------------------------
 
 static void Barrier(ID3D12Resource *res, D3D12_RESOURCE_STATES from, D3D12_RESOURCE_STATES to);   // defined below
 
 static const UINT kMvProbeSize  = 64;
 static const UINT kMvProbePitch = 256;   // 64 texels of R16G16_FLOAT = 256 bytes = the D3D12 row-pitch alignment
-static const UINT kMvProbeEvery = 600;
+static const UINT kDepthProbeSize       = 32;
+static const UINT kDepthProbePitch      = 256;   // one R32_FLOAT row, padded to D3D12's alignment
+static const UINT kDepthProbeBlocks     = 4;
+static const UINT kDepthProbeBlockBytes = kDepthProbePitch * kDepthProbeSize;
+static const UINT kGuideProbeEvery      = 600;
+static_assert(kMvProbePitch % D3D12_TEXTURE_DATA_PITCH_ALIGNMENT == 0);
+static_assert(kDepthProbePitch % D3D12_TEXTURE_DATA_PITCH_ALIGNMENT == 0);
+static_assert(kDepthProbeBlockBytes % D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT == 0);
 
 static ID3D12Resource *g_mv_probe_buf;
-static UINT64          g_mv_probe_fence;    // fence value that completes the pending copy; 0 = nothing pending
-static UINT64          g_mv_probe_frames;
+static ID3D12Resource *g_depth_probe_buf;
+static UINT64          g_guide_probe_fence;    // fence value that completes the pending copies; 0 = nothing pending
+static UINT64          g_guide_probe_frames;
+static UINT64          g_guide_probe_capture_frame;
 static char            g_mv_probe[200] = "no motion-vector probe yet (first one after 600 frames)";
+static char            g_depth_probe[240] = "no depth probe yet (first one after 600 frames)";
 
 static float HalfToFloat(uint16_t h)
 {
@@ -890,25 +900,75 @@ static void MvProbeAnalyse()
     g_mv_probe_buf->Unmap(0, &none);
     const int total = static_cast<int>(kMvProbeSize * kMvProbeSize);
     _snprintf_s(g_mv_probe, sizeof(g_mv_probe), _TRUNCATE,
-                "MV probe (centre 64x64, frame %llu): mean |mv| %.3f px, max %.2f px, %d%% non-zero%s",
-                static_cast<unsigned long long>(g_mv_probe_frames), sum / total, maxlen, nonzero * 100 / total,
-                nonzero * 100 / total < 2 ? "  <-- DLSS is getting (almost) no motion vectors" : "");
+                 "MV probe (centre 64x64, frame %llu): mean |mv| %.3f px, max %.2f px, %d%% non-zero%s",
+                 static_cast<unsigned long long>(g_guide_probe_capture_frame), sum / total, maxlen, nonzero * 100 / total,
+                 nonzero * 100 / total < 2 ? "  <-- DLSS is getting (almost) no motion vectors" : "");
     Log("[feed] %s", g_mv_probe);
 }
 
-// Call while recording, with the MV texture in 'state' (it is returned to that state).
-static void MvProbeRecord(ID3D12Resource *mv, D3D12_RESOURCE_STATES state)
+static void DepthProbeAnalyse()
 {
-    if (mv == nullptr || g.dev12 == nullptr || g.list == nullptr || g.fence12 == nullptr) return;
-    if ((++g_mv_probe_frames % kMvProbeEvery) != 0) return;
-    if (g.width < kMvProbeSize || g.height < kMvProbeSize) return;
+    if (g_depth_probe_buf == nullptr) return;
+    void *p = nullptr;
+    const D3D12_RANGE read = { 0, kDepthProbeBlockBytes * kDepthProbeBlocks };
+    if (FAILED(g_depth_probe_buf->Map(0, &read, &p)) || p == nullptr) return;
 
-    if (g_mv_probe_fence != 0)
+    double sum = 0.0, sum2 = 0.0, min_depth = 1e300, max_depth = -1e300;
+    int finite = 0;
+    for (UINT block = 0; block < kDepthProbeBlocks; ++block)
+        for (UINT y = 0; y < kDepthProbeSize; ++y)
+        {
+            const float *row = reinterpret_cast<const float *>(
+                static_cast<const uint8_t *>(p) + block * kDepthProbeBlockBytes + y * kDepthProbePitch);
+            for (UINT x = 0; x < kDepthProbeSize; ++x)
+            {
+                const double d = row[x];
+                if (!std::isfinite(d)) continue;
+                sum += d;
+                sum2 += d * d;
+                if (d < min_depth) min_depth = d;
+                if (d > max_depth) max_depth = d;
+                ++finite;
+            }
+        }
+
+    const D3D12_RANGE none = { 0, 0 };
+    g_depth_probe_buf->Unmap(0, &none);
+    const int total = static_cast<int>(kDepthProbeSize * kDepthProbeSize * kDepthProbeBlocks);
+    const double mean = finite > 0 ? sum / finite : 0.0;
+    const double variance = finite > 0 ? (std::max)(0.0, sum2 / finite - mean * mean) : 0.0;
+    const bool flat = finite == 0 || max_depth - min_depth < 1e-6;
+    _snprintf_s(g_depth_probe, sizeof(g_depth_probe), _TRUNCATE,
+                "Depth probe (4x 32x32, frame %llu): min %.6g, max %.6g, mean %.6g, variance %.3g, %d%% finite%s",
+                static_cast<unsigned long long>(g_guide_probe_capture_frame),
+                finite > 0 ? min_depth : 0.0, finite > 0 ? max_depth : 0.0, mean, variance,
+                finite * 100 / total,
+                flat ? "  <-- sampled depth is flat; inspect the depth debug view / Generic Depth settings" : "");
+    Log("[feed] %s", g_depth_probe);
+}
+
+static void GuideProbeAnalyse()
+{
+    MvProbeAnalyse();
+    DepthProbeAnalyse();
+}
+
+// Call while recording; both textures are returned to their incoming states.
+static void GuideProbeRecord(ID3D12Resource *mv, D3D12_RESOURCE_STATES mv_state,
+                             ID3D12Resource *depth, D3D12_RESOURCE_STATES depth_state)
+{
+    if (mv == nullptr || depth == nullptr || g.dev12 == nullptr || g.list == nullptr || g.fence12 == nullptr) return;
+    ++g_guide_probe_frames;
+
+    if (g_guide_probe_fence != 0)
     {
-        if (g.fence12->GetCompletedValue() < g_mv_probe_fence) return;   // still in flight (should not happen at this cadence)
-        MvProbeAnalyse();
-        g_mv_probe_fence = 0;
+        if (g.fence12->GetCompletedValue() < g_guide_probe_fence) return;
+        GuideProbeAnalyse();
+        g_guide_probe_fence = 0;
+        g_guide_probe_capture_frame = 0;
     }
+    if ((g_guide_probe_frames % kGuideProbeEvery) != 0) return;
+    if (g.width < kMvProbeSize || g.height < kMvProbeSize) return;
     if (g_mv_probe_buf == nullptr)
     {
         D3D12_HEAP_PROPERTIES hp = {}; hp.Type = D3D12_HEAP_TYPE_READBACK;
@@ -921,6 +981,18 @@ static void MvProbeRecord(ID3D12Resource *mv, D3D12_RESOURCE_STATES state)
             return;
     }
 
+    if (g_depth_probe_buf == nullptr)
+    {
+        D3D12_HEAP_PROPERTIES hp = {}; hp.Type = D3D12_HEAP_TYPE_READBACK;
+        D3D12_RESOURCE_DESC   rd = {};
+        rd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER; rd.Width = kDepthProbeBlockBytes * kDepthProbeBlocks;
+        rd.Height = 1; rd.DepthOrArraySize = 1; rd.MipLevels = 1; rd.SampleDesc.Count = 1;
+        rd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        if (FAILED(g.dev12->CreateCommittedResource(&hp, D3D12_HEAP_FLAG_NONE, &rd, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+                                                    __uuidof(ID3D12Resource), reinterpret_cast<void **>(&g_depth_probe_buf))))
+            return;
+    }
+
     D3D12_TEXTURE_COPY_LOCATION src = {};
     src.pResource = mv; src.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX; src.SubresourceIndex = 0;
     D3D12_TEXTURE_COPY_LOCATION dst = {};
@@ -930,21 +1002,42 @@ static void MvProbeRecord(ID3D12Resource *mv, D3D12_RESOURCE_STATES state)
     const UINT x0 = (g.width - kMvProbeSize) / 2, y0 = (g.height - kMvProbeSize) / 2;
     const D3D12_BOX box = { x0, y0, 0, x0 + kMvProbeSize, y0 + kMvProbeSize, 1 };
 
-    if (state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(mv, state, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    if (mv_state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(mv, mv_state, D3D12_RESOURCE_STATE_COPY_SOURCE);
     g.list->CopyTextureRegion(&dst, 0, 0, 0, &src, &box);
-    if (state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(mv, D3D12_RESOURCE_STATE_COPY_SOURCE, state);
-    g_mv_probe_fence = g.fence_value + 1;   // exactly what EndCommands() signals for this list
+    if (mv_state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(mv, D3D12_RESOURCE_STATE_COPY_SOURCE, mv_state);
+
+    D3D12_TEXTURE_COPY_LOCATION depth_src = {};
+    depth_src.pResource = depth; depth_src.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX; depth_src.SubresourceIndex = 0;
+    if (depth_state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(depth, depth_state, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    for (UINT block = 0; block < kDepthProbeBlocks; ++block)
+    {
+        D3D12_TEXTURE_COPY_LOCATION depth_dst = {};
+        depth_dst.pResource = g_depth_probe_buf; depth_dst.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+        depth_dst.PlacedFootprint.Offset = block * kDepthProbeBlockBytes;
+        depth_dst.PlacedFootprint.Footprint = { DXGI_FORMAT_R32_FLOAT, kDepthProbeSize, kDepthProbeSize, 1, kDepthProbePitch };
+        const UINT x0 = ((block & 1) ? 3 : 1) * (g.width - kDepthProbeSize) / 4;
+        const UINT y0 = ((block & 2) ? 3 : 1) * (g.height - kDepthProbeSize) / 4;
+        const D3D12_BOX depth_box = { x0, y0, 0, x0 + kDepthProbeSize, y0 + kDepthProbeSize, 1 };
+        g.list->CopyTextureRegion(&depth_dst, 0, 0, 0, &depth_src, &depth_box);
+    }
+    if (depth_state != D3D12_RESOURCE_STATE_COPY_SOURCE) Barrier(depth, D3D12_RESOURCE_STATE_COPY_SOURCE, depth_state);
+    g_guide_probe_capture_frame = g_guide_probe_frames;
+    g_guide_probe_fence = g.fence_value + 1;   // exactly what EndCommands() signals for this list
 }
 
-static void MvProbeAbort()
+static void GuideProbeAbort()
 {
-    g_mv_probe_fence = 0;
+    g_guide_probe_fence = 0;
+    g_guide_probe_capture_frame = 0;
 }
 
-static void MvProbeShutdown()
+static void GuideProbeShutdown()
 {
     SafeRelease(g_mv_probe_buf);
-    g_mv_probe_fence = 0;
+    SafeRelease(g_depth_probe_buf);
+    g_guide_probe_fence = 0;
+    g_guide_probe_frames = 0;
+    g_guide_probe_capture_frame = 0;
 }
 
 static void SafeReleaseFeature(NVSDK_NGX_Handle *f)
@@ -1490,7 +1583,7 @@ static void ShutdownSession()
     if (g.fence_event != nullptr) { CloseHandle(g.fence_event); g.fence_event = nullptr; }
     SafeRelease(g.list);
     for (int i = 0; i < Feed::kFrames; ++i) SafeRelease(g.alloc[i]);
-    MvProbeShutdown();
+    GuideProbeShutdown();
     SafeRelease(g.queue);
     SafeRelease(g.dev12);
     g.session_ready = false;
@@ -2630,7 +2723,8 @@ static void FeedFrame12(reshade::api::effect_runtime *rt, reshade::api::command_
                 g.need_reset = false;
 
                 // ReShade parked the effect textures as shader_resource (both SR states on D3D12).
-                MvProbeRecord(mv, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                GuideProbeRecord(mv, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                                 depth, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 
                 NVSDK_NGX_D3D12_DLSS_Eval_Params ep = {};
                 ep.Feature.pInColor  = g.tex12[SLOT_COLOR];
@@ -2913,7 +3007,8 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 Barrier(g.tex12[SLOT_DEPTH],  D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_MV],     D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 if (g.mask_ok) Barrier(g.tex12[SLOT_MASK], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-                MvProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                GuideProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                                 g.tex12[SLOT_DEPTH], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_OUTPUT], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
                 NVSDK_NGX_D3D12_DLSS_Eval_Params ep = {};
@@ -3193,7 +3288,8 @@ static void FeedFrameGl(reshade::api::effect_runtime *rt, reshade::api::command_
                 Barrier(g.tex12[SLOT_DEPTH],  D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_MV],     D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 if (g.mask_ok) Barrier(g.tex12[SLOT_MASK], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-                MvProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                GuideProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                                 g.tex12[SLOT_DEPTH], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_OUTPUT], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
                 NVSDK_NGX_D3D12_DLSS_Eval_Params ep = {};
@@ -3433,7 +3529,8 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
                 Barrier(g.tex12[SLOT_DEPTH],  D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_MV],     D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 if (g.mask_ok) Barrier(g.tex12[SLOT_MASK], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-                MvProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                GuideProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                                 g.tex12[SLOT_DEPTH], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                 Barrier(g.tex12[SLOT_OUTPUT], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
                 const int reset = (g.need_reset || g_cfg.reset_every) ? 1 : 0;
@@ -3790,6 +3887,11 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
                        "0 texMotionVectors (qUINT, dh_uber_motion), 1 Launchpad, 2 VORT, 3 LumeniteFX Kernel, 4 LumeniteFX QuantMotion.");
     if (ImGui::SliderFloat("MV scale X", &g_cfg.mv_scale_x, 0.0f, 4.0f)) dirty = true;
     if (ImGui::SliderFloat("MV scale Y", &g_cfg.mv_scale_y, 0.0f, 4.0f)) dirty = true;
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Depth");
+    ImGui::TextWrapped("%s", g_depth_probe);
+    ImGui::TextWrapped("A flat sample is a diagnostic warning, not an automatic disable: inspect the shader's depth debug view and Generic Depth settings.");
 
     if (ImGui::CollapsingHeader("Advanced"))
     {


### PR DESCRIPTION
This adds content-level depth diagnostics and removes the redundant fullscreen depth pass without changing the DLSS contract or the raw guide values.

### What changed

- Write motion vectors, the trust mask, and raw hardware depth in one MRT guide pass.
- Read back small, infrequent MV/depth samples after GPU completion and report whether the actual guides handed to DLSS are non-zero, finite, and non-flat. The deferred probe is wired into the D3D11, D3D12, Vulkan, and newly merged OpenGL paths.
- Make the depth debug view readable with a display-only contrast curve. `DLSS5_Depth` itself remains raw.
- Document the `ReShade.fxh` dependency and a contributor-verified Subnautica Generic Depth profile.

This follows the useful content-versus-handle and depth-clear observations in #9. It also addresses the missing-header portion of #4, but does not claim to resolve every setup/compiler failure reported there.

### Review follow-up

- Rebased onto current `main`, including #19 and the OpenGL path.
- Removed the D3D11 `CopyResource` fast path entirely from both x64 and x86. The original shader blit remains the only copy-back path, preserving its forced `alpha = 1.0` behavior and making the RTV-slot and log-latch concerns in the review inapplicable.
- Marked the Subnautica result as contributor-verified pending maintainer retest.

### Validation

- MSVC x64 and x86 compile/link: pass.
- ReShadeFX 6.8 parser: all five MV provider modes, normal and reversed depth: pass.
- Microsoft shader compiler: modified guide pixel shader compiles with three render targets.
- Subnautica, 3840x2160, D3D11: DLAA contract created, Reno NR feature 18 created/evaluated, MV samples 98–100% non-zero, distributed depth samples 100% finite and non-flat.

The runtime test proves correct activation and guide contents, not a total-FPS uplift. An older matched benchmark did not establish a performance gain, so this PR intentionally makes no FPS claim.

### Coverage limits

- Runtime coverage was on 64-bit D3D11. The final capture-frame bookkeeping and rebase integration were compile-tested after that session.
- The x86 path is build-tested, not runtime-tested.
- D3D12, Vulkan, and OpenGL guide-probe call sites are compile/static-tested, not runtime-tested here.
- This does not attempt to fix the format/color-space reports in #11 or #14; those need separate, API-specific validation.

Addresses part of #4. Follow-up to #9.
