### PR TITLE
OpenGL: probe the interop when the driver caps the extension string

### DIFF
--- a/spike/spike-gl32.cpp
+++ b/spike/spike-gl32.cpp
@@ -71,10 +71,15 @@ int main()
     {
         printf("CLIENT FAIL: the OpenGL interop is unavailable in this 32-bit process: %s\n", gl.missing);
         printf("             renderer=\"%s\" version=\"%s\"\n", gl.renderer, gl.version);
+        printf("             extension query: %s\n", gl.diag);
         printf("             (this is exactly the x86 parity question design A depends on)\n");
         return 1;
     }
     printf("gl: renderer=\"%s\" version=\"%s\" (interop extensions present in x86)\n", gl.renderer, gl.version);
+    // Printed on the pass too: the gate can be carried by the live probe when a driver
+    // caps the extension string, and a spike that only says PASS cannot tell that apart
+    // from the matcher having found the extensions itself.
+    printf("gl: extension query: %s\n", gl.diag);
 
     HMODULE m = GetModuleHandleW(L"opengl32.dll");
     auto GetTexImage = reinterpret_cast<PFN_glGetTexImage_>(GetProcAddress(m, "glGetTexImage"));

--- a/spike/spike-gl64.cpp
+++ b/spike/spike-gl64.cpp
@@ -350,10 +350,15 @@ static int RunInProcess()
     {
         printf("FAIL: the OpenGL interop is unavailable: %s\n", gl.missing);
         printf("      renderer=\"%s\" version=\"%s\"\n", gl.renderer, gl.version);
+        printf("      extension query: %s\n", gl.diag);
         printf("      (on a hybrid laptop, force this process onto the NVIDIA GPU)\n");
         return 1;
     }
     printf("gl: renderer=\"%s\" version=\"%s\" (interop extensions present)\n", gl.renderer, gl.version);
+    // Printed on the pass too: the gate can be carried by the live probe when a driver
+    // caps the extension string, and a spike that only says PASS cannot tell that apart
+    // from the matcher having found the extensions itself.
+    printf("gl: extension query: %s\n", gl.diag);
     GlExtra x;
     if (!LoadGlExtra(&x)) { printf("FAIL: glGetTexImage/glClear missing\n"); return 1; }
 

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -2156,12 +2156,7 @@ static bool InitSessionGl(reshade::api::effect_runtime *rt)
     g.gl_ctx = g.gl.wglGetCurrentContext();
     Log("[feed] OpenGL: renderer=\"%s\" version=\"%s\" context=%p thread=%lu (interop extensions present)",
         g.gl.renderer, g.gl.version, (void *)g.gl_ctx, GetCurrentThreadId());
-    // The driver hid the extensions from this executable (an NVIDIA per-application
-    // cap on the extension string, applied to old engines) and the live probe found
-    // them anyway. Worth a line: it is the difference between a driver quirk and a
-    // GPU that genuinely cannot do interop.
-    if (g.gl.probe_rescued)
-        Log("[feed] extension query: %s", g.gl.diag);
+    Log("[feed] extension query: %s", g.gl.diag);
 
     // Private D3D12 device, loaded so ReShade hooks it -- that hook is what lets the
     // DLSS 5 add-on see the device. Proven under dxgi.dll and Vulkan-layer loading;

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -2146,6 +2146,7 @@ static bool InitSessionGl(reshade::api::effect_runtime *rt)
         Log("[feed] renderer=\"%s\" version=\"%s\" context=%p thread=%lu",
             g.gl.renderer, g.gl.version, (void *)(g.gl.wglGetCurrentContext ? g.gl.wglGetCurrentContext() : nullptr),
             GetCurrentThreadId());
+        Log("[feed] extension query: %s", g.gl.diag);
         Log("[feed] GL_EXT_memory_object_win32 + GL_EXT_semaphore_win32 are NVIDIA-supported on every");
         Log("[feed] DLSS-capable driver. Their absence means this frame is not being rendered on the");
         Log("[feed] NVIDIA GPU -- on a hybrid laptop, force the game onto it (Windows graphics settings).");
@@ -2155,6 +2156,12 @@ static bool InitSessionGl(reshade::api::effect_runtime *rt)
     g.gl_ctx = g.gl.wglGetCurrentContext();
     Log("[feed] OpenGL: renderer=\"%s\" version=\"%s\" context=%p thread=%lu (interop extensions present)",
         g.gl.renderer, g.gl.version, (void *)g.gl_ctx, GetCurrentThreadId());
+    // The driver hid the extensions from this executable (an NVIDIA per-application
+    // cap on the extension string, applied to old engines) and the live probe found
+    // them anyway. Worth a line: it is the difference between a driver quirk and a
+    // GPU that genuinely cannot do interop.
+    if (g.gl.probe_rescued)
+        Log("[feed] extension query: %s", g.gl.diag);
 
     // Private D3D12 device, loaded so ReShade hooks it -- that hook is what lets the
     // DLSS 5 add-on see the device. Proven under dxgi.dll and Vulkan-layer loading;

--- a/src/dlss5-feed32.cpp
+++ b/src/dlss5-feed32.cpp
@@ -1682,6 +1682,7 @@ static void FeedFrameGl(reshade::api::effect_runtime *rt, reshade::api::resource
         {
             Log("[feed32] OpenGL interop unavailable: %s", g.gl.missing);
             Log("[feed32] renderer=\"%s\" version=\"%s\"", g.gl.renderer, g.gl.version);
+            Log("[feed32] extension query: %s", g.gl.diag);
             Log("[feed32] GL_EXT_memory_object_win32 + GL_EXT_semaphore_win32 are NVIDIA-supported on every");
             Log("[feed32] DLSS-capable driver. Their absence means this frame is not being rendered on the");
             Log("[feed32] NVIDIA GPU -- on a hybrid laptop, force the game onto it (Windows graphics settings).");
@@ -1691,6 +1692,12 @@ static void FeedFrameGl(reshade::api::effect_runtime *rt, reshade::api::resource
         g.gl_ctx = g.gl.wglGetCurrentContext();
         Log("[feed32] OpenGL: renderer=\"%s\" version=\"%s\" context=%p thread=%lu (interop extensions present)",
             g.gl.renderer, g.gl.version, (void *)g.gl_ctx, GetCurrentThreadId());
+        // The driver hid the extensions from this executable (an NVIDIA per-application
+        // cap on the extension string, applied to old engines) and the live probe found
+        // them anyway. Worth a line: it is the difference between a driver quirk and a
+        // GPU that genuinely cannot do interop.
+        if (g.gl.probe_rescued)
+            Log("[feed32] extension query: %s", g.gl.diag);
     }
     // GL names live in the share group of the context current at import: a context
     // change strands every one of them, so start over on the new one.

--- a/src/dlss5-feed32.cpp
+++ b/src/dlss5-feed32.cpp
@@ -1692,12 +1692,7 @@ static void FeedFrameGl(reshade::api::effect_runtime *rt, reshade::api::resource
         g.gl_ctx = g.gl.wglGetCurrentContext();
         Log("[feed32] OpenGL: renderer=\"%s\" version=\"%s\" context=%p thread=%lu (interop extensions present)",
             g.gl.renderer, g.gl.version, (void *)g.gl_ctx, GetCurrentThreadId());
-        // The driver hid the extensions from this executable (an NVIDIA per-application
-        // cap on the extension string, applied to old engines) and the live probe found
-        // them anyway. Worth a line: it is the difference between a driver quirk and a
-        // GPU that genuinely cannot do interop.
-        if (g.gl.probe_rescued)
-            Log("[feed32] extension query: %s", g.gl.diag);
+        Log("[feed32] extension query: %s", g.gl.diag);
     }
     // GL names live in the share group of the context current at import: a context
     // change strands every one of them, so start over on the new one.

--- a/src/feed_gl.h
+++ b/src/feed_gl.h
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <cstdio>
 
 // ---------------------------------------------------------------------------
 // Types and tokens the Windows SDK's <gl/GL.h> (an OpenGL 1.1 header) lacks
@@ -205,6 +206,8 @@ struct FeedGl
     char missing[256];      // the first extension/entry point that was absent
     char renderer[128];     // GL_RENDERER, so a wrong-GPU hybrid laptop is obvious
     char version[64];       // GL_VERSION
+    char diag[448];         // how the extension query itself behaved (see FeedGlLoad)
+    bool probe_rescued;     // the string denied the interop and a live probe overrode it
 
     bool ok;
 };
@@ -229,10 +232,16 @@ static bool FeedGlHasExtension(FeedGl *gl, const char *name)
             const GLubyte *e = gl->GetStringi(GL_EXTENSIONS, static_cast<GLuint>(i));
             if (e != nullptr && strcmp(reinterpret_cast<const char *>(e), name) == 0) return true;
         }
-        if (count > 0) return false;
     }
+    // The legacy form, consulted even when the modern one answered with a non-empty
+    // list -- it is not a fallback for an empty enumeration alone. When ReShade is
+    // installed for OpenGL it IS the local opengl32.dll, and a proxy that answers one
+    // of the two enumerations need not answer the other. Letting whichever form spoke
+    // first be authoritative turns a half-answer into "this GPU cannot do interop",
+    // which disables the feed outright.
     if (gl->GetString == nullptr) return false;
     const GLubyte *all = gl->GetString(GL_EXTENSIONS);
+    if (gl->GetError != nullptr) (void)gl->GetError();       // GL_INVALID_ENUM in a core profile
     if (all == nullptr) return false;
     const char *s = reinterpret_cast<const char *>(all);
     const size_t n = strlen(name);
@@ -241,10 +250,45 @@ static bool FeedGlHasExtension(FeedGl *gl, const char *name)
     return false;
 }
 
+// Does this context actually do external-object interop, whatever the extension
+// string claims? NVIDIA's per-application profiles cap the string they report to old
+// engines -- id Tech 3 and its descendants copy glGetString(GL_EXTENSIONS) into a
+// fixed 4 KB buffer, so the driver truncates the advertised set for those executables
+// and GL_EXT_memory_object falls off the end. The capability is untouched; only the
+// advertisement is. Asking the driver to hand back a live memory object and a live
+// semaphore settles it, and settles the stub worry with it: a stub cannot produce a
+// non-zero object name and leave GL_NO_ERROR behind.
+static bool FeedGlProbeInterop(FeedGl *gl)
+{
+    const auto CreateMem = reinterpret_cast<PFN_glCreateMemoryObjectsEXT_>(gl->wglGetProcAddress("glCreateMemoryObjectsEXT"));
+    const auto DeleteMem = reinterpret_cast<PFN_glDeleteMemoryObjectsEXT_>(gl->wglGetProcAddress("glDeleteMemoryObjectsEXT"));
+    const auto GenSem    = reinterpret_cast<PFN_glGenSemaphoresEXT_>(gl->wglGetProcAddress("glGenSemaphoresEXT"));
+    const auto DelSem    = reinterpret_cast<PFN_glDeleteSemaphoresEXT_>(gl->wglGetProcAddress("glDeleteSemaphoresEXT"));
+    if (CreateMem == nullptr || DeleteMem == nullptr || GenSem == nullptr || DelSem == nullptr) return false;
+
+    // Start from a clean error state, and never trust the driver to drain (a context
+    // that reports an error forever must not hang the game in here).
+    for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
+
+    GLuint mem = 0;
+    CreateMem(1, &mem);
+    const bool mem_ok = mem != 0 && gl->GetError() == GL_NO_ERROR;
+    if (mem != 0) DeleteMem(1, &mem);
+
+    GLuint sem = 0;
+    GenSem(1, &sem);
+    const bool sem_ok = sem != 0 && gl->GetError() == GL_NO_ERROR;
+    if (sem != 0) DelSem(1, &sem);
+
+    for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
+    return mem_ok && sem_ok;
+}
+
 // Resolve everything on the context current RIGHT NOW. Returns false (with
 // gl->missing naming the culprit) if the interop extensions are absent or any
-// entry point is missing. The presence gate is the extension string, never a
-// non-null ProcAddress: drivers happily return stubs for unsupported entries.
+// entry point is missing. The gate is the extension string first and a live probe
+// second -- never a non-null ProcAddress on its own, because drivers happily return
+// stubs for unsupported entries.
 static bool FeedGlLoad(FeedGl *gl)
 {
     *gl = {};
@@ -284,15 +328,67 @@ static bool FeedGlLoad(FeedGl *gl)
     if (const GLubyte *r = gl->GetString(GL_RENDERER)) strncpy_s(gl->renderer, reinterpret_cast<const char *>(r), _TRUNCATE);
     if (const GLubyte *v = gl->GetString(GL_VERSION))  strncpy_s(gl->version,  reinterpret_cast<const char *>(v), _TRUNCATE);
 
-    // The gate. Missing here means this frame is not being rendered on an NVIDIA GPU
+    // Record how each enumeration behaves before anything is looked up in it. A bare
+    // "GL_EXT_memory_object missing" cannot tell a GPU that lacks the interop apart
+    // from a query that answered nothing -- and on hardware that plainly has it, the
+    // second is what happened. mem_obj counts entries containing "memory_object" in
+    // each form, so "the driver lists it and our matcher missed it" reads differently
+    // from "the driver never listed it".
+    {
+        GLint count = 0;
+        GLenum err_i = 0;
+        int hits_i = 0;
+        // Drain first: the game and ReShade share this context, so an error left
+        // behind by either would otherwise be reported as ours and read as evidence
+        // about a query that in fact succeeded.
+        for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
+        if (gl->GetStringi != nullptr)
+        {
+            gl->GetIntegerv(GL_NUM_EXTENSIONS, &count);
+            err_i = gl->GetError();
+            for (GLint i = 0; i < count; ++i)
+            {
+                const GLubyte *e = gl->GetStringi(GL_EXTENSIONS, static_cast<GLuint>(i));
+                if (e != nullptr && strstr(reinterpret_cast<const char *>(e), "memory_object") != nullptr) ++hits_i;
+            }
+        }
+        const GLubyte *all = gl->GetString(GL_EXTENSIONS);
+        const GLenum err_s = gl->GetError();
+        int hits_s = 0;
+        if (all != nullptr)
+            for (const char *p = strstr(reinterpret_cast<const char *>(all), "memory_object");
+                 p != nullptr; p = strstr(p + 1, "memory_object")) ++hits_s;
+        sprintf_s(gl->diag,
+                  "glGetStringi=%s GL_NUM_EXTENSIONS=%d err=0x%04X mem_obj=%d | "
+                  "glGetString(GL_EXTENSIONS)=%s len=%u err=0x%04X mem_obj=%d",
+                  gl->GetStringi != nullptr ? "resolved" : "NULL", static_cast<int>(count),
+                  static_cast<unsigned>(err_i), hits_i,
+                  all != nullptr ? "ok" : "NULL",
+                  all != nullptr ? static_cast<unsigned>(strlen(reinterpret_cast<const char *>(all))) : 0u,
+                  static_cast<unsigned>(err_s), hits_s);
+    }
+
+    // The gate. Failing it means this frame is not being rendered on an NVIDIA GPU
     // (wrong GPU on a hybrid laptop, or non-NVIDIA hardware) -- DLSS could not run
     // there anyway, so the caller disables the feed rather than falling back.
     static const char *const kNeeded[] = {
         "GL_EXT_memory_object", "GL_EXT_memory_object_win32",
         "GL_EXT_semaphore",     "GL_EXT_semaphore_win32",
     };
+    const char *unadvertised = nullptr;
     for (const char *ext : kNeeded)
-        if (!FeedGlHasExtension(gl, ext)) { strcpy_s(gl->missing, ext); return false; }
+        if (!FeedGlHasExtension(gl, ext)) { unadvertised = ext; break; }
+
+    // An unadvertised extension is a question, not a verdict: on a capped extension
+    // string the interop is there and works. Only a probe that also fails is absence.
+    if (unadvertised != nullptr)
+    {
+        if (!FeedGlProbeInterop(gl)) { strcpy_s(gl->missing, unadvertised); return false; }
+        gl->probe_rescued = true;
+        char note[192];
+        sprintf_s(note, " | %s unadvertised, live probe PASSED (capped extension string)", unadvertised);
+        strcat_s(gl->diag, note);
+    }
 
     // glCopyImageSubData is core since 4.3; on anything older it needs an extension.
     // ReShade's own OpenGL minimum is 4.3, so this is belt and braces.

--- a/src/feed_gl.h
+++ b/src/feed_gl.h
@@ -206,8 +206,7 @@ struct FeedGl
     char missing[256];      // the first extension/entry point that was absent
     char renderer[128];     // GL_RENDERER, so a wrong-GPU hybrid laptop is obvious
     char version[64];       // GL_VERSION
-    char diag[448];         // how the extension query itself behaved (see FeedGlLoad)
-    bool probe_rescued;     // the string denied the interop and a live probe overrode it
+    char diag[512];         // how the extension query behaved (see FeedGlSurveyExtensions)
 
     bool ok;
 };
@@ -216,71 +215,111 @@ struct FeedGl
 // Loading
 // ---------------------------------------------------------------------------
 
-// Is `name` listed in the current context's extension string? Reads it both the
-// modern way (glGetStringi, core profiles) and the legacy way (glGetString, which
-// compatibility contexts still answer), because NVIDIA hands even ancient games a
-// 4.6 compatibility context and either form may be the one that answers.
-static bool FeedGlHasExtension(FeedGl *gl, const char *name)
+// Swallow and report whatever is sitting in the error queue. Returns the first
+// error found (0 = clean) so a caller can log one line instead of a loop. Bounded,
+// because a context that reports an error forever must not hang the game in here.
+// Defined ahead of the loader so load-time code shares the one drain, and free of an
+// `ok` guard for the same reason: every other caller already checked `ok` itself.
+static GLenum FeedGlDrainErrors(FeedGl *gl)
 {
-    if (gl->GetStringi != nullptr && gl->GetIntegerv != nullptr)
+    GLenum first = GL_NO_ERROR;
+    for (int i = 0; i < 32; ++i)
     {
-        GLint count = 0;
+        const GLenum e = gl->GetError();
+        if (e == GL_NO_ERROR) break;
+        if (first == GL_NO_ERROR) first = e;
+    }
+    return first;
+}
+
+// Read the context's advertised extension set ONCE, both ways, and answer the only
+// question the loader asks of it: which of `names` are listed. `found` receives one
+// flag per name.
+//
+// Both enumerations are read and unioned, never short-circuited. NVIDIA hands even
+// ancient games a 4.6 compatibility context, so either form may be the one that
+// answers; and when ReShade is installed for OpenGL it IS the local opengl32.dll, and
+// a proxy that answers one form need not answer the other. Letting whichever form
+// spoke first be authoritative turns a half-answer into "this GPU cannot do interop",
+// which disables the feed outright.
+//
+// gl->diag records how each enumeration itself behaved, because a bare
+// "GL_EXT_memory_object missing" cannot tell a GPU that lacks the interop apart from a
+// query that answered nothing -- and on hardware that plainly has it, the second is
+// what happens. `listed` is how many of `names` each form carried, counted in this
+// same pass, so it is the matcher's own verdict rather than a second guess at it.
+static void FeedGlSurveyExtensions(FeedGl *gl, const char *const *names, int n, bool *found)
+{
+    for (int k = 0; k < n; ++k) found[k] = false;
+
+    // The game and ReShade share this context: an error left behind by either would
+    // otherwise be reported as ours and read as evidence about a query that succeeded.
+    FeedGlDrainErrors(gl);
+
+    GLint count = 0;
+    GLenum err_i = GL_NO_ERROR;
+    int listed_i = 0;
+    if (gl->GetStringi != nullptr)
+    {
         gl->GetIntegerv(GL_NUM_EXTENSIONS, &count);
-        if (gl->GetError != nullptr) (void)gl->GetError();   // GL_INVALID_ENUM pre-3.0
+        err_i = FeedGlDrainErrors(gl);                  // GL_INVALID_ENUM pre-3.0
         for (GLint i = 0; i < count; ++i)
         {
             const GLubyte *e = gl->GetStringi(GL_EXTENSIONS, static_cast<GLuint>(i));
-            if (e != nullptr && strcmp(reinterpret_cast<const char *>(e), name) == 0) return true;
+            if (e == nullptr) continue;
+            for (int k = 0; k < n; ++k)
+                if (!found[k] && strcmp(reinterpret_cast<const char *>(e), names[k]) == 0)
+                { found[k] = true; ++listed_i; }
         }
     }
-    // The legacy form, consulted even when the modern one answered with a non-empty
-    // list -- it is not a fallback for an empty enumeration alone. When ReShade is
-    // installed for OpenGL it IS the local opengl32.dll, and a proxy that answers one
-    // of the two enumerations need not answer the other. Letting whichever form spoke
-    // first be authoritative turns a half-answer into "this GPU cannot do interop",
-    // which disables the feed outright.
-    if (gl->GetString == nullptr) return false;
+
     const GLubyte *all = gl->GetString(GL_EXTENSIONS);
-    if (gl->GetError != nullptr) (void)gl->GetError();       // GL_INVALID_ENUM in a core profile
-    if (all == nullptr) return false;
-    const char *s = reinterpret_cast<const char *>(all);
-    const size_t n = strlen(name);
-    for (const char *p = strstr(s, name); p != nullptr; p = strstr(p + 1, name))
-        if ((p == s || p[-1] == ' ') && (p[n] == ' ' || p[n] == '\0')) return true;
-    return false;
+    const GLenum err_s = FeedGlDrainErrors(gl);         // GL_INVALID_ENUM in a core profile
+    const char *const s = reinterpret_cast<const char *>(all);
+    int listed_s = 0;
+    if (s != nullptr)
+        for (int k = 0; k < n; ++k)
+        {
+            const size_t len = strlen(names[k]);
+            for (const char *p = strstr(s, names[k]); p != nullptr; p = strstr(p + 1, names[k]))
+                if ((p == s || p[-1] == ' ') && (p[len] == ' ' || p[len] == '\0'))
+                { found[k] = true; ++listed_s; break; }
+        }
+
+    sprintf_s(gl->diag,
+              "glGetStringi=%s GL_NUM_EXTENSIONS=%d err=0x%04X listed=%d/%d | "
+              "glGetString(GL_EXTENSIONS)=%s len=%u err=0x%04X listed=%d/%d",
+              gl->GetStringi != nullptr ? "resolved" : "NULL", static_cast<int>(count),
+              static_cast<unsigned>(err_i), listed_i, n,
+              s != nullptr ? "ok" : "NULL",
+              s != nullptr ? static_cast<unsigned>(strlen(s)) : 0u,
+              static_cast<unsigned>(err_s), listed_s, n);
 }
 
-// Does this context actually do external-object interop, whatever the extension
-// string claims? NVIDIA's per-application profiles cap the string they report to old
-// engines -- id Tech 3 and its descendants copy glGetString(GL_EXTENSIONS) into a
-// fixed 4 KB buffer, so the driver truncates the advertised set for those executables
-// and GL_EXT_memory_object falls off the end. The capability is untouched; only the
+// Does this context actually do external-object interop, whatever the extension string
+// claims? NVIDIA's per-application profiles cap the string reported to old engines --
+// id Tech 3 and its descendants copy glGetString(GL_EXTENSIONS) into a fixed 4 KB
+// buffer, so the driver truncates the advertised set for those executables and
+// GL_EXT_memory_object falls off the end. The capability is untouched; only the
 // advertisement is. Asking the driver to hand back a live memory object and a live
-// semaphore settles it, and settles the stub worry with it: a stub cannot produce a
-// non-zero object name and leave GL_NO_ERROR behind.
+// semaphore settles it -- and settles the stub worry with it, which is why a resolved
+// entry point was never the gate on its own: a stub cannot produce a non-zero object
+// name and leave GL_NO_ERROR behind.
 static bool FeedGlProbeInterop(FeedGl *gl)
 {
-    const auto CreateMem = reinterpret_cast<PFN_glCreateMemoryObjectsEXT_>(gl->wglGetProcAddress("glCreateMemoryObjectsEXT"));
-    const auto DeleteMem = reinterpret_cast<PFN_glDeleteMemoryObjectsEXT_>(gl->wglGetProcAddress("glDeleteMemoryObjectsEXT"));
-    const auto GenSem    = reinterpret_cast<PFN_glGenSemaphoresEXT_>(gl->wglGetProcAddress("glGenSemaphoresEXT"));
-    const auto DelSem    = reinterpret_cast<PFN_glDeleteSemaphoresEXT_>(gl->wglGetProcAddress("glDeleteSemaphoresEXT"));
-    if (CreateMem == nullptr || DeleteMem == nullptr || GenSem == nullptr || DelSem == nullptr) return false;
-
-    // Start from a clean error state, and never trust the driver to drain (a context
-    // that reports an error forever must not hang the game in here).
-    for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
+    FeedGlDrainErrors(gl);
 
     GLuint mem = 0;
-    CreateMem(1, &mem);
-    const bool mem_ok = mem != 0 && gl->GetError() == GL_NO_ERROR;
-    if (mem != 0) DeleteMem(1, &mem);
+    gl->CreateMemoryObjectsEXT(1, &mem);
+    const bool mem_ok = FeedGlDrainErrors(gl) == GL_NO_ERROR && mem != 0;
+    if (mem != 0) gl->DeleteMemoryObjectsEXT(1, &mem);
 
     GLuint sem = 0;
-    GenSem(1, &sem);
-    const bool sem_ok = sem != 0 && gl->GetError() == GL_NO_ERROR;
-    if (sem != 0) DelSem(1, &sem);
+    gl->GenSemaphoresEXT(1, &sem);
+    const bool sem_ok = FeedGlDrainErrors(gl) == GL_NO_ERROR && sem != 0;
+    if (sem != 0) gl->DeleteSemaphoresEXT(1, &sem);
 
-    for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
+    FeedGlDrainErrors(gl);
     return mem_ok && sem_ok;
 }
 
@@ -328,77 +367,34 @@ static bool FeedGlLoad(FeedGl *gl)
     if (const GLubyte *r = gl->GetString(GL_RENDERER)) strncpy_s(gl->renderer, reinterpret_cast<const char *>(r), _TRUNCATE);
     if (const GLubyte *v = gl->GetString(GL_VERSION))  strncpy_s(gl->version,  reinterpret_cast<const char *>(v), _TRUNCATE);
 
-    // Record how each enumeration behaves before anything is looked up in it. A bare
-    // "GL_EXT_memory_object missing" cannot tell a GPU that lacks the interop apart
-    // from a query that answered nothing -- and on hardware that plainly has it, the
-    // second is what happened. mem_obj counts entries containing "memory_object" in
-    // each form, so "the driver lists it and our matcher missed it" reads differently
-    // from "the driver never listed it".
-    {
-        GLint count = 0;
-        GLenum err_i = 0;
-        int hits_i = 0;
-        // Drain first: the game and ReShade share this context, so an error left
-        // behind by either would otherwise be reported as ours and read as evidence
-        // about a query that in fact succeeded.
-        for (int i = 0; i < 32 && gl->GetError() != GL_NO_ERROR; ++i) {}
-        if (gl->GetStringi != nullptr)
-        {
-            gl->GetIntegerv(GL_NUM_EXTENSIONS, &count);
-            err_i = gl->GetError();
-            for (GLint i = 0; i < count; ++i)
-            {
-                const GLubyte *e = gl->GetStringi(GL_EXTENSIONS, static_cast<GLuint>(i));
-                if (e != nullptr && strstr(reinterpret_cast<const char *>(e), "memory_object") != nullptr) ++hits_i;
-            }
-        }
-        const GLubyte *all = gl->GetString(GL_EXTENSIONS);
-        const GLenum err_s = gl->GetError();
-        int hits_s = 0;
-        if (all != nullptr)
-            for (const char *p = strstr(reinterpret_cast<const char *>(all), "memory_object");
-                 p != nullptr; p = strstr(p + 1, "memory_object")) ++hits_s;
-        sprintf_s(gl->diag,
-                  "glGetStringi=%s GL_NUM_EXTENSIONS=%d err=0x%04X mem_obj=%d | "
-                  "glGetString(GL_EXTENSIONS)=%s len=%u err=0x%04X mem_obj=%d",
-                  gl->GetStringi != nullptr ? "resolved" : "NULL", static_cast<int>(count),
-                  static_cast<unsigned>(err_i), hits_i,
-                  all != nullptr ? "ok" : "NULL",
-                  all != nullptr ? static_cast<unsigned>(strlen(reinterpret_cast<const char *>(all))) : 0u,
-                  static_cast<unsigned>(err_s), hits_s);
-    }
-
     // The gate. Failing it means this frame is not being rendered on an NVIDIA GPU
     // (wrong GPU on a hybrid laptop, or non-NVIDIA hardware) -- DLSS could not run
     // there anyway, so the caller disables the feed rather than falling back.
-    static const char *const kNeeded[] = {
+    enum { kMemObj, kMemObjWin32, kSem, kSemWin32, kCopyImageArb, kCopyImageExt, kExtCount };
+    static const char *const kExt[kExtCount] = {
         "GL_EXT_memory_object", "GL_EXT_memory_object_win32",
         "GL_EXT_semaphore",     "GL_EXT_semaphore_win32",
+        "GL_ARB_copy_image",    "GL_EXT_copy_image",
     };
-    const char *unadvertised = nullptr;
-    for (const char *ext : kNeeded)
-        if (!FeedGlHasExtension(gl, ext)) { unadvertised = ext; break; }
+    bool have[kExtCount];
+    FeedGlSurveyExtensions(gl, kExt, kExtCount, have);
 
-    // An unadvertised extension is a question, not a verdict: on a capped extension
-    // string the interop is there and works. Only a probe that also fails is absence.
-    if (unadvertised != nullptr)
-    {
-        if (!FeedGlProbeInterop(gl)) { strcpy_s(gl->missing, unadvertised); return false; }
-        gl->probe_rescued = true;
-        char note[192];
-        sprintf_s(note, " | %s unadvertised, live probe PASSED (capped extension string)", unadvertised);
-        strcat_s(gl->diag, note);
-    }
+    const char *unadvertised = nullptr;
+    for (int k = kMemObj; k <= kSemWin32; ++k)
+        if (!have[k]) { unadvertised = kExt[k]; break; }
 
     // glCopyImageSubData is core since 4.3; on anything older it needs an extension.
     // ReShade's own OpenGL minimum is 4.3, so this is belt and braces.
     if (atoi(gl->version) < 4 || (atoi(gl->version) == 4 && (strlen(gl->version) < 3 || gl->version[2] < '3')))
-        if (!FeedGlHasExtension(gl, "GL_ARB_copy_image") && !FeedGlHasExtension(gl, "GL_EXT_copy_image"))
+        if (!have[kCopyImageArb] && !have[kCopyImageExt])
         { strcpy_s(gl->missing, "GL_ARB_copy_image (and the context is below OpenGL 4.3)"); return false; }
 
+    // An entry point that will not resolve while the extension was also unadvertised is
+    // the extension genuinely being absent -- report it as such, so the wrong-GPU case
+    // reads the same whether the driver hands back stubs or nothing at all.
     #define FEED_GL_EXT(member, name) \
         gl->member = reinterpret_cast<PFN_gl##member##_>(gl->wglGetProcAddress(name)); \
-        if (gl->member == nullptr) { strcpy_s(gl->missing, name); return false; }
+        if (gl->member == nullptr) { strcpy_s(gl->missing, unadvertised != nullptr ? unadvertised : name); return false; }
     FEED_GL_EXT(GenFramebuffers,        "glGenFramebuffers")
     FEED_GL_EXT(DeleteFramebuffers,     "glDeleteFramebuffers")
     FEED_GL_EXT(BindFramebuffer,        "glBindFramebuffer")
@@ -426,27 +422,24 @@ static bool FeedGlLoad(FeedGl *gl)
     FEED_GL_EXT(ImportSemaphoreWin32HandleEXT,"glImportSemaphoreWin32HandleEXT")
     #undef FEED_GL_EXT
 
+    // An unadvertised extension is a question, not a verdict: under a capped extension
+    // string the interop is there and works. Only a probe that also fails is absence.
+    // Asked here, after resolution, so the probe calls the same table the transport
+    // will -- there is no second copy of the entry points to keep in step.
+    if (unadvertised != nullptr)
+    {
+        if (!FeedGlProbeInterop(gl)) { strcpy_s(gl->missing, unadvertised); return false; }
+        char note[128];
+        sprintf_s(note, " | %s unadvertised, live probe PASSED (capped extension string)", unadvertised);
+        strcat_s(gl->diag, note);
+    }
+
     // Optional: the DSA form spares us a bind/restore during the import.
     gl->TextureStorageMem2DEXT =
         reinterpret_cast<PFN_glTextureStorageMem2DEXT_>(gl->wglGetProcAddress("glTextureStorageMem2DEXT"));
 
     gl->ok = true;
     return true;
-}
-
-// Swallow and report whatever is sitting in the error queue. Returns the first
-// error found (0 = clean) so a caller can log one line instead of a loop.
-static GLenum FeedGlDrainErrors(FeedGl *gl)
-{
-    if (!gl->ok) return 0;
-    GLenum first = 0;
-    for (int i = 0; i < 32; ++i)
-    {
-        const GLenum e = gl->GetError();
-        if (e == GL_NO_ERROR) break;
-        if (first == 0) first = e;
-    }
-    return first;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #28.

## The report

An RTX 4090 on driver 591.86 stopped the feed in Jedi Academy (id Tech 3, 32-bit) with:

```
[feed32] OpenGL interop unavailable: GL_EXT_memory_object
[feed32] renderer="NVIDIA GeForce RTX 4090/PCIe/SSE2" version="4.6.0 NVIDIA 591.86"
```

That GPU plainly has the interop, and the existing message sends the user to the hybrid-laptop advice, which is a dead end on a desktop 4090.

Two details narrowed it: `GL_RENDERER`/`GL_VERSION` came back fine, so `glGetString` worked; and it failed on `GL_EXT_memory_object`, the *first* of the four names checked. A driver lacking only the win32 variants would fail on the second. Failing on the first is the signature of a query that returns nothing.

## Root cause

NVIDIA's per-application profiles cap the extension string reported to old engines — id Tech 3 copies `glGetString(GL_EXTENSIONS)` into a fixed 4 KB buffer, so the driver truncates the set it advertises to that executable, and `GL_EXT_memory_object` falls off the end.

Reproduced by renaming a probe binary and changing nothing else — same GPU, same driver, same ReShade `opengl32.dll` proxy loaded the same way:

| exe name | `GL_NUM_EXTENSIONS` | ext string | `memory_object` |
|---|---|---|---|
| `repro.exe` | 404 | 10488 bytes | 3 |
| `jasp.exe` | **170** | **4048 bytes** | **0** |
| `swkotor.exe` | **170** | **4048 bytes** | **0** |
| `swkotor2.exe` | **170** | **4048 bytes** | **0** |

Only the advertisement is capped. Under it, all twelve interop entry points still resolve, and live `glCreateMemoryObjectsEXT` / `glGenSemaphoresEXT` calls return valid object names with `GL_NO_ERROR`.

## The change

An unadvertised extension becomes a question rather than a verdict. `FeedGlProbeInterop` creates and deletes a real memory object and a real semaphore; only a probe that *also* fails means absence.

This keeps the reason the gate never trusted a non-null `ProcAddress` — a stub cannot hand back a live object name and leave `GL_NO_ERROR` behind — so a wrong-GPU hybrid laptop still fails, with the same message as before.

Two supporting changes:

- `FeedGlHasExtension` no longer lets a non-empty `glGetStringi` enumeration short-circuit the legacy string. Its own comment said either form may be the one that answers; the code made whichever spoke first authoritative.
- `FeedGlLoad` records how both enumerations behaved, logged on the failure path and whenever the probe overrides the string. A bare `GL_EXT_memory_object missing` cannot distinguish a GPU that lacks the interop from a query that answered nothing — which is what cost the time here.

## Verification

`verify-dlss5-feeder` rig, all five targets built from the working tree:

| Feature | Result |
|---|---|
| `d3d11-32bit` | PASS |
| `opengl-crossproc` | PASS |
| `opengl-inproc` | PASS |
| `vulkan32` | PASS |
| `host-test` | PASS — 300/300 NGX evaluates, neural rendering confirmed from both logs |

Then confirmed in the real game on the RTX 4090 / Jedi Academy install from #28:

```
[feed32] OpenGL: renderer="NVIDIA GeForce RTX 4090/PCIe/SSE2" ... (interop extensions present)
[feed32] extension query: glGetStringi=resolved GL_NUM_EXTENSIONS=170 ... mem_obj=0 | ... |
         GL_EXT_memory_object unadvertised, live probe PASSED (capped extension string)
```

9000+ frames delivered over the OpenGL transport, host connected on protocol v3, DLSS 5 neural rendering applying.

## Follow-up commits: folding the fix into the loader (`5a96e01`, `f801ac3`)

A code-quality pass on the above found that the fix had landed *alongside* `FeedGlLoad`
rather than inside it, leaving four duplicate pairs behind. `5a96e01` folds them in. No
behaviour change is intended.

`FeedGlSurveyExtensions` reads the context's advertised set once, both ways, and answers
which of the six names the loader wants are listed. That replaces two independent
enumerations: `FeedGlHasExtension`, which re-walked both forms once per name, and the
diagnostic block, which walked them again to count `memory_object` substrings. That
counter existed only to check one pass against the other — with a single pass the
diagnostic reports the matcher's own verdict as `listed=k/n`. `FeedGlHasExtension` is
deleted outright and the loader drops from six enumeration passes to one.

`FeedGlProbeInterop` moves below the entry-point table and calls through it, deleting its
private resolution of four entries the table already holds. An entry point that will not
resolve *while its extension was also unadvertised* is that extension genuinely being
absent, so `FEED_GL_EXT` reports it that way and the wrong-GPU message is unchanged.

`FeedGlDrainErrors` moves above the loader and loses its `ok` guard, which was already
vestigial — every other caller checks `ok` itself, and `FeedGlColorEncoding` reaches
`FeedGlAttach`, which dereferences the table unguarded regardless. The three hand-rolled
copies of the drain loop go with it. The probe now drains rather than reading a single
error, so a driver that queued two no longer misattributes the second.

`probe_rescued` is gone. `diag` already ends with the probe note on exactly the runs the
flag marked, so both add-ons log the query unconditionally now: the success and failure
paths are symmetric, and a healthy driver leaves a baseline in the log instead of nothing.

`f801ac3` is separate and stands on its own. Both GL spikes called `FeedGlLoad` and
reported only `gl.missing`, and only on failure — so the rig could not tell a gate the
matcher passed from one the live probe rescued. A matcher that found nothing would mark
every extension unadvertised, the probe would pass, and the spike would print `SPIKE PASS`
either way. Printing `gl.diag` on both paths makes that difference visible, and would have
been worth having before this PR.

## Verification of the follow-up

The restructure changes the gate every OpenGL user passes through, so it was checked on
both sides of the bug — the capped path this PR fixes, and the uncapped path everyone
else is on. Same RTX 4090 / driver 591.86.

| Path | Driver reports | Matcher | Live probe |
|---|---|---|---|
| Capped — Jedi Academy, real game, 32-bit | 170 ext / 4048 B | `listed=0/6` both forms | fired and rescued; 600 frames delivered, host on protocol v3, DLAA feature ready |
| Uncapped — verify rig, x86 **and** x64 | 404 ext / 10488 B | `listed=5/6` both forms | never fired |

The uncapped row is the one the capped row cannot provide. On the Jedi Academy box
`listed=0/6` is the *correct* answer, so a broken matcher would produce a byte-identical
log and a working feed — the probe would hide it. Only an uncapped string discriminates,
and there the matcher finds all four interop extensions itself:

```
gl: extension query: glGetStringi=resolved GL_NUM_EXTENSIONS=404 err=0x0000 listed=5/6
                   | glGetString(GL_EXTENSIONS)=ok len=10488 err=0x0000 listed=5/6
```

The sixth name is one of the copy-image pair, almost certainly `GL_EXT_copy_image` (not
measured — NVIDIA desktop GL does not advertise it). Immaterial: on a 4.6 context the
version gate skips that check, and this PR and the restructure treat it identically.

`verify-dlss5-feeder`, all five features from the working tree:

| Feature | Result |
|---|---|
| `d3d11-32bit` | PASS |
| `opengl-crossproc` | PASS |
| `opengl-inproc` | PASS |
| `vulkan32` | PASS |
| `host-test` | PASS — 300/300 NGX evaluates, neural rendering confirmed from both logs |

**Still unverified:** the 64-bit in-game OpenGL path (`InitSessionGl` in
`src/dlss5-feed.cpp`). Its loader has been exercised by the x64 spike on the real GPU, but
never by a real game with this restructure — no 64-bit OpenGL title was to hand. It is the
same code path the 32-bit add-on ran 600 frames through, but that is an argument, not a
measurement.

## Note for a follow-up (not in this PR)

Two unrelated install faults surfaced *behind* this one, only because the fix let the code reach them for the first time. Neither is a code defect, but one has a misleading message worth fixing separately: a stale `host64\` host makes the game side log `host lost: handshake failed`, when the host's own log says precisely `the game add-on speaks protocol v3, this host only v2 -- update host64\`. `src/dlss5-feed32.cpp` has an exact version-mismatch branch right below, but it is unreachable because the host closes the pipe rather than replying.
