### PR TITLE
Fix early Vulkan submission ordering in 64-bit mode 2 (Detroit flicker)

### DIFF
--- a/INVESTIGATION-DETROIT64.md
+++ b/INVESTIGATION-DETROIT64.md
@@ -1,0 +1,154 @@
+# Detroit Vulkan: early-submit dependency gap
+
+Base: upstream `v0.14.0-beta.2`, commit `5cd502677ac187959530d2ae679005cdff83880d`.
+Experimental build: `0.14.0-beta.2-detroit-sync.1`. Only the 64-bit add-on is changed.
+
+## Finding and confidence
+
+There is a concrete missing dependency at the boundary between ReShade's present
+handling and the feeder's early Vulkan flush. A deterministic two-queue GPU test
+reproduces stale capture without the dependency and fresh capture with it on the
+reported RTX 4070 SUPER / driver 616.56. The reporter subsequently tested this
+build in Detroit and confirmed that it works. This is user-reported in-game
+validation; the precise diagnostic settings and test duration were not supplied.
+DOOM regression testing and the full diagnostic matrix remain outstanding.
+
+The older Smooth Motion conclusion in `PLAN-DETROIT.md` does not settle this new
+reproduction. Issue [#13](https://github.com/jlrouzies-fr/DLSS5-Feeder/issues/13)
+remains relevant historical evidence; its report is not a test of this patch.
+The [beta.2 release](https://github.com/jlrouzies-fr/DLSS5-Feeder/releases/tag/v0.14.0-beta.2)
+also contains changes absent from local main, which is why the patch uses the tag.
+
+## Exact control-flow difference
+
+| Operation | mode=1 | mode=2 | mode=2, passthrough=1 |
+|---|---|---|---|
+| Capture callback RTV, depth, MV | Yes | Yes | Yes |
+| Input route | Imported images, Vulkan only | Imported images or linear buffers | Same as mode=2 |
+| External ownership release | No | Yes | Yes |
+| Flush inside technique callback | No | Yes | Yes |
+| Vulkan signal / D3D12 wait | No | Yes | Yes |
+| D3D12 per-frame work | None | EvaluateFeature | CopyResource(OUTPUT, COLOR) |
+| D3D12 signal / Vulkan wait | No | Yes | Yes |
+| Return ownership / reacquire native command buffer | No | Yes | Yes |
+| Copy home | Left half of COLOR | OUTPUT, full image by default | Same as mode=2 |
+
+NGX initialization/feature creation are still retained by passthrough to isolate
+the per-frame evaluate difference. In unmodified beta.2, differing COLOR/OUTPUT
+formats silently fall back to EvaluateFeature even with passthrough enabled.
+This build explicitly stops that diagnostic instead of pretending it bypassed
+NGX. Use matching formats, confirmed in the log. Restart between transport
+configuration tests: beta.2's feature-only rebuild can retain existing textures.
+
+## Why the existing fences do not protect capture
+
+In [ReShade 6.8's Vulkan present hook](https://github.com/crosire/reshade/blob/v6.8.0/source/vulkan/vulkan_hooks_swapchain.cpp),
+`present_effect_runtime()` runs before the final immediate-list submission is
+connected to `VkPresentInfoKHR::pWaitSemaphores`. The feeder's mode-2 callback
+flushes earlier. Its own input fence certifies completion of that early capture,
+but cannot make the capture wait for game work on another queue.
+
+The patch captures present context at the device-dispatch entry (including calls
+that bypass the loader export). Inside the callback, under ReShade's queue locks,
+it queues waits for **all** original binary present semaphores before the first
+operation that may flush. It then re-signals those binary semaphores once, so
+ReShade can consume its unchanged final wait list. This uses ReShade queue APIs,
+without CPU waiting or raw queue submissions in the add-on. The value zero is
+ignored for binary semaphores as specified by
+[VkTimelineSemaphoreSubmitInfo](https://docs.vulkan.org/refpages/latest/refpages/source/VkTimelineSemaphoreSubmitInfo.html).
+The gate runs once per present. An unavailable context or a different callback
+command list makes mode 2 skip, with an explicit log; that is not a successful fix.
+
+The first re-signal may flush the already-recorded effects, adding a submission.
+Measure performance in-game. `vk_present_sync=0` restores the original dependency
+behaviour for a controlled A/B comparison; default is `1`. The existing async-home
+experiments should remain off for these comparisons.
+
+## Image identity and lifetime
+
+ReShade derives its current index from the **presented** index before effects.
+The most recently acquired image is not necessarily the presented image, so it
+would be incorrect to substitute a separately cached acquire index. Its runtime
+can also pass a resolved/format-conversion intermediate RTV and later copy that
+to the swapchain. Thus RTV != swapchain image alone is not a bug.
+
+The patch keeps the callback RTV and compares its resource mapping across the
+flush. It logs the present-request index, corresponding image, capture/home
+resources, intermediate status, queue identities, native command buffers and
+the feeder timeline values together. It does not claim to measure compositor
+scanout or independently hook every acquire call. The direct path should report
+`intermediate=0 stable=1 copied=1`; an intermediate path requires the runtime's
+later resolve/copy and is labelled explicitly.
+
+A separate lifetime defect was found: `ReleaseFrameResources` drained only the
+private D3D12 queue before destroying Vulkan imports. It now also retires Vulkan
+use. The device-destruction callback clears the queue pointer because ReShade
+has already destroyed queue wrappers at that point.
+
+## The stale hash is consistent with a black centre
+
+Applying the existing hash algorithm to 4096 repetitions of bytes `00 00 00 FF`
+produces **`5f9eb3fedcef8383`**, exactly the supplied hash. Therefore the old
+64x64 centre sample is consistent with an opaque black area in RGBA8/BGRA8, even
+if other pixels are changing. A hash match is not proof of texture-wide staleness.
+The old probe also read COLOR **after**, rather than before, evaluation.
+
+With `vk_trace=1`, the new probe samples three 16x16 tiles at quarter, centre and
+three-quarter positions every 60 mode-2 frames:
+
+| Stage | Resource / recording point |
+|---|---|
+| A | Callback source, before capture |
+| B | Imported COLOR image after capture, or the populated linear input buffer |
+| C | Exact D3D12 pInColor texture, before evaluate/copy |
+| D | Exact D3D12 pInOutput texture, after evaluate/copy |
+| E | Imported OUTPUT image or active linear output buffer after the return wait |
+| F | Copy-home destination after the copy |
+
+F is the swapchain image on the direct path. For an intermediate RTV it is
+labelled `F=effect-target`; the final runtime resolve/scanout remains unmeasured.
+Probe hashes exclude row padding; CPU reads wait for both APIs. Vulkan buffers
+use explicitly coherent memory through ReShade's upload heap because its Vulkan
+map API does not invalidate noncoherent readback memory. `uniform=...` marks
+spatially constant samples, not a claim about the complete image.
+
+For equal-format passthrough, A=B=C=D=E=F is expected. With NGX, compare A=B=C and
+D=E=F separately. Format conversion invalidates byte equality across conversion.
+The probe skips historical-output and half-copy modes. It adds a diagnostic
+flush once per sample, so also retest with `vk_trace=0` before accepting a fix.
+
+## Validation and next game test
+
+`build.bat`: x64 MSVC compile and link succeeded. `tests/test-vk-present-order.bat`
+runs on the real GPU with two queues and a deliberately delayed producer. Eight
+iterations each demonstrated fresh deferred capture, stale unguarded early
+capture, and fresh gated early capture. All final binary waits retired, including
+reuse across frames. This tests the shared wait/re-signal helper used by the patch.
+The automated test does not run NGX, validate the ReShade detour in a game, or
+test visual flicker. Separately, the reporter confirmed the build works in
+Detroit. The six-stage readback logs and DOOM regression remain outstanding.
+No 32-bit targets built.
+
+Back up the existing add-on and use `build/dlss5-feed.addon64` next to the game's
+executable. Verify the log version suffix `detroit-sync.1`. Preserve the existing
+game configuration and use these diagnostic overrides where needed:
+
+```ini
+enabled=1
+mode=2
+passthrough=1
+vk_present_sync=1
+vk_trace=1
+async_home=0
+half_home=0
+sync_home=0
+```
+
+First confirm actual delivered frames and the `ordered=1` identity lines; a
+skipped feeder that happens not to flicker is a failed test. Compare passthrough
+with sync disabled/enabled, then `passthrough=0` for real DLAA. Pan across a scene
+with detail in all three sampled regions for at least 300 delivered frames.
+Test both linear-buffer and imported-image transport (`buffer_home=1/0`, with
+restarts), and retest the working mode-1 baseline. Repeat the same matrix in
+DOOM 2016 Vulkan. Finish with tracing off, then exercise resolution changes,
+alt-tab and effect reload. Restore the original add-on to roll back.

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -57,11 +57,12 @@
 #include "feed_crash.h" // naming a C++ throw and the modules it came through, shared with host64
 #include "feed_vk.h"   // raw-Vulkan interop for the Vulkan transport (see PLAN-VULKAN)
 #include "feed_vk_hook.h"   // in-process vkCreateDevice hook: appends the interop extensions the transport needs
+#include "feed_vk_present64.h"
 #include "feed_gl.h"   // raw-OpenGL interop for the OpenGL transport (see PLAN-OPENGL)
 #include "feed_dfc.h"  // Deep Fried Chicken interop ABI 1 (producer side)
 #include "feed_fsr1.h" // AMD FSR 1 EASU + RCAS: the optional expand-back for work_resolution < 100%
 
-#define FEED_VERSION "0.14.0-beta.2"
+#define FEED_VERSION "0.14.0-beta.2-detroit-sync.1"
 
 extern "C" __declspec(dllexport) const char *NAME = "DLSS 5 Feed " FEED_VERSION;
 extern "C" __declspec(dllexport) const char *DESCRIPTION =
@@ -918,9 +919,11 @@ struct Cfg
                            // of a stable image on a static scene. Parse-only, not written back.
     int   jitter_phases;   // diagnostic for work_upscale=2: Halton sequence length, 0 = auto
                            // (8 * (native/work)^2, NVIDIA's guidance). Parse-only.
+    int   vk_present_sync; // 1: order early Vulkan submits against the game's present waits
+    int   vk_trace;        // per-frame identities + six-stage readbacks (diagnostic only)
 };
 
-static Cfg g_cfg = { 1, 2, -1, -1, -1, 0, 180, 0, 3, 60, 0, 100, 0, 0.3f, 2000, 1, 0, 0, 0, 0, 1.0f, 1.0f, 50, 1, 0 };
+static Cfg g_cfg = { 1, 2, -1, -1, -1, 0, 180, 0, 3, 60, 0, 100, 0, 0.3f, 2000, 1, 0, 0, 0, 0, 1.0f, 1.0f, 50, 1, 0, 1, 0 };
 static int       g_work_resolution_ui = 100;
 static int       g_pending_work_resolution = 0;
 static ULONGLONG g_work_resolution_apply_after = 0;
@@ -1006,6 +1009,8 @@ static bool CfgReload()
         else if (_stricmp(key, "sync_home")      == 0) next.sync_home      = iv;
         else if (_stricmp(key, "half_home")      == 0) next.half_home      = iv;
         else if (_stricmp(key, "passthrough")    == 0) next.passthrough    = iv;
+        else if (_stricmp(key, "vk_present_sync") == 0) next.vk_present_sync = iv;
+        else if (_stricmp(key, "vk_trace")        == 0) next.vk_trace = iv;
         else if (_stricmp(key, "mv_scale_x")     == 0) next.mv_scale_x     = val;
         else if (_stricmp(key, "mv_scale_y")     == 0) next.mv_scale_y     = val;
         else if (_stricmp(key, "stall_log_ms")   == 0) next.stall_log_ms   = iv;
@@ -2495,10 +2500,10 @@ static void GuideProbeRecord(ID3D12Resource *mv, D3D12_RESOURCE_STATES mv_state,
 // D3D12 view of the colour INPUT (exactly what the evaluate is about to read) and of
 // the OUTPUT (exactly what the evaluate just wrote) into a readback buffer, hash both
 // once the fence confirms completion, and log whether each changed since the previous
-// probe. When the screen freezes but every frame reports "delivered", this says WHICH
-// hop of the cross-API transport is stale: colour-in SAME = the Vulkan->D3D12 input
-// copy is not landing; colour-in CHANGED but output SAME = DLSS is producing a
-// constant; both CHANGED = the D3D12->Vulkan copy home is the stale hop.
+// probe. This samples only the centre AFTER evaluate; a constant centre does not
+// prove that the full input is stale. In particular, 5f9eb3fedcef8383 is also the
+// hash of a 64x64 opaque-black RGBA8/BGRA8 tile. Vulkan's opt-in six-stage probe
+// below reads three distributed tiles, including COLOR before evaluate.
 // ---------------------------------------------------------------------------
 
 static const UINT kStaleProbeSize = 64;
@@ -2565,13 +2570,17 @@ static void StaleProbeAnalyse()
     if (FAILED(g_stale_buf->Map(0, &read, &p)) || p == nullptr) return;
     const uint64_t hc = StaleProbeHash(static_cast<const uint8_t *>(p), g_stale_bytes[0]);
     const uint64_t ho = StaleProbeHash(static_cast<const uint8_t *>(p) + kStaleProbeBlock, g_stale_bytes[1]);
+    uint32_t first[2] = {};
+    memcpy(&first[0], p, sizeof(uint32_t));
+    memcpy(&first[1], static_cast<const uint8_t *>(p) + kStaleProbeBlock, sizeof(uint32_t));
     const D3D12_RANGE none = { 0, 0 };
     g_stale_buf->Unmap(0, &none);
     if (g_stale_have_hash)
-        Log("[feed] stale probe (frame %llu): colour-in %s (%016llx), output %s (%016llx)",
+        Log("[feed] stale probe (frame %llu): colour-in %s (%016llx), output %s (%016llx); centre64 first32=%08x/%08x fmt=%u/%u",
             static_cast<unsigned long long>(g_stale_capture_frame),
             hc == g_stale_hash[0] ? "SAME" : "changed", static_cast<unsigned long long>(hc),
-            ho == g_stale_hash[1] ? "SAME" : "changed", static_cast<unsigned long long>(ho));
+            ho == g_stale_hash[1] ? "SAME" : "changed", static_cast<unsigned long long>(ho),
+            first[0], first[1], static_cast<unsigned>(g.color_fmt), static_cast<unsigned>(g.output_fmt));
     g_stale_hash[0] = hc;
     g_stale_hash[1] = ho;
     g_stale_have_hash = true;
@@ -2636,6 +2645,8 @@ static void StaleProbeRecord(ID3D12Resource *color, D3D12_RESOURCE_STATES color_
     g_stale_fence = g.fence_value + 1;   // exactly what EndCommands() signals for this list
 }
 
+#include "feed_vk_probe64.h"
+
 static void GuideProbeAbort()
 {
     g_guide_probe_fence = 0;
@@ -2682,7 +2693,11 @@ static void Barrier(ID3D12Resource *res, D3D12_RESOURCE_STATES from, D3D12_RESOU
 
 static void ReleaseFrameResources()
 {
+    // The private fence retires D3D12 only. Vulkan may still have copy-home
+    // commands referencing these imports (including on the immediate list).
+    if (g.vk.ok && g.rs_queue && (g.vk_img[SLOT_COLOR] || g_vk_probe.dev)) g.rs_queue->wait_idle();
     DrainGpu();
+    FeedVkProbeRelease();
     // Vulkan transport: drop our raw VkImage imports (the memory is the D3D12 resource's;
     // freeing the import does not free the D3D12 resource, which SafeRelease(tex12) does).
     if (g.vk.ok)
@@ -5241,8 +5256,18 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
         return;
     }
 
+    // Even a resource rebuild can flush the immediate list. Establish the game
+    // dependency before that, not just before the explicit per-frame flush.
+    if (g_cfg.vk_present_sync && !g_vk_frame_present_target) FeedVkFramePresentInstall(rt);
+    if (g_cfg.mode >= 2 && g_cfg.vk_present_sync && !FeedVkOrderPresent(rt, cl))
+    {
+        static bool reported = false;
+        if (!reported) { reported = true; Log("[feed] Vulkan: no usable present dependency context; skipping mode 2 to avoid an unordered early submit"); }
+        return;
+    }
     bool ok = true;
-    if (g.session_ready && g.rs_dev != nullptr && g.rs_dev != dev_api)
+    if (g.session_ready && g.rs_dev != nullptr &&
+        (g.rs_dev != dev_api || g.rs_queue != rt->get_command_queue()))
     {
         Log("[feed] the game recreated its device; rebuilding the session");
         ShutdownSession();
@@ -5275,7 +5300,14 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
 
     if (ok && g.frame_ready)
     {
+        if (g_cfg.passthrough && g_cfg.mode >= 2 && g.color_fmt != g.output_fmt)
+        {
+            FeedDisable("passthrough requires matching COLOR/OUTPUT formats; NGX was NOT called");
+            return;
+        }
+        FeedVkProbeBegin(rt, bb_res);
         VkCommandBuffer cb = FeedVkDispatch<VkCommandBuffer>(cl->get_native());
+        const uint64_t capture_cb = FeedVkValue(cb);
         VkImage bb_img = FeedVkHandle<VkImage>(bb_res.handle);
         VkImage mv_img = FeedVkHandle<VkImage>(mv_res.handle);
         VkImage dp_img = FeedVkHandle<VkImage>(depth_res.handle);
@@ -5336,6 +5368,7 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
         }
         const bool staged_in = g_cfg.mode >= 2 && g.vk_in_buf[SLOT_COLOR] != VK_NULL_HANDLE;
         const UINT cbpp = HomeTexelBytes(g.color_fmt) != 0 ? HomeTexelBytes(g.color_fmt) : 4;
+        FeedVkProbeVk(cb, 0, bb_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL); // A: source before capture
         if (staged_in)
         {
             FeedVkCopyImageToBuffer(&g.vk, cb, bb_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, g.vk_in_buf[SLOT_COLOR], w, h, g.in_pitch[SLOT_COLOR] / cbpp);
@@ -5347,6 +5380,21 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
             FeedVkCopyImage(&g.vk, cb, bb_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, g.vk_img[SLOT_COLOR], VK_IMAGE_LAYOUT_GENERAL, w, h);
             FeedVkCopyImage(&g.vk, cb, mv_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, g.vk_img[SLOT_MV],    VK_IMAGE_LAYOUT_GENERAL, w, h);
             FeedVkCopyImage(&g.vk, cb, dp_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, g.vk_img[SLOT_DEPTH], VK_IMAGE_LAYOUT_GENERAL, w, h);
+        }
+        if (g_vk_probe.active)
+        {
+            // Publish the capture to the B read, even though both use transfer commands.
+            if (staged_in)
+            {
+                VkMemoryBarrier barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
+                barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                g.vk.CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0, 1, &barrier, 0, nullptr, 0, nullptr);
+            }
+            else FeedVkBarrier(&g.vk, cb, g.vk_img[SLOT_COLOR], VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL);
+            FeedVkProbeVk(cb, 1, g.vk_img[SLOT_COLOR], VK_IMAGE_LAYOUT_GENERAL,
+                staged_in ? g.vk_in_buf[SLOT_COLOR] : VK_NULL_HANDLE, g.in_pitch[SLOT_COLOR]);
         }
         if (g.mask_ok)
         {
@@ -5388,6 +5436,10 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 cl->barrier(1, res, from, to);
             }
             ++g.frames_done;
+            if (g_cfg.vk_trace)
+                FeedVkIdentity(rt, cl, rtv, bb_res, g.frames_done, capture_cb,
+                    FeedVkValue(g.vk_img[SLOT_COLOR]), FeedVkValue(g.vk_img[SLOT_OUTPUT]),
+                    g.tex12[SLOT_COLOR], g.tex12[SLOT_OUTPUT], 0, 0, true);
         }
         else
         {
@@ -5513,6 +5565,7 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 ep.InExposureScale   = 1.0f;
 
                 Breadcrumb("running the D3D12 evaluate (Vulkan transport)");
+                FeedVkProbeD12(false); // C: exact pInColor, before EvaluateFeature/CopyResource
                 DWORD ecode = 0;
                 NVSDK_NGX_Result re;
                 if (g_cfg.passthrough != 0 && g.color_fmt == g.output_fmt)
@@ -5542,6 +5595,7 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 }
                 else
                 {
+                    FeedVkProbeD12(true); // D: exact pInOutput, after EvaluateFeature/CopyResource
                     StaleProbeRecord(g.tex12[SLOT_COLOR],  D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                                      g.tex12[SLOT_OUTPUT], D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
                     if (g.home_buf12 != nullptr)
@@ -5595,6 +5649,10 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
             if (one_submit)
             {
                 // Nothing more to record: the copy home already went out with the inputs.
+                if (g_cfg.vk_trace)
+                    FeedVkIdentity(rt, cl, rtv, bb_res, g.vk_frame, capture_cb,
+                        FeedVkValue(g.vk_img[SLOT_COLOR]), FeedVkValue(g.vk_img[SLOT_OUTPUT]),
+                        g.tex12[SLOT_COLOR], g.tex12[SLOT_OUTPUT], n, n > 1 ? n - 1 : 0, n > 1);
                 static bool said_one = false;
                 if (!said_one)
                 {
@@ -5646,6 +5704,13 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                     static_cast<unsigned long long>(FeedVkTimelineValue(&g.vk, g.vk_sem_out)));
             cb = FeedVkDispatch<VkCommandBuffer>(cl->get_native());  // fresh buffer after the flush
             done = done && home_ok;   // async_home frame 1: nothing to carry home yet
+            // A flush changes the native command buffer, not the RTV's owner. Do
+            // not silently redirect output to another image if that contract breaks.
+            if (dev_api->get_resource_from_view(rtv) != bb_res)
+            {
+                Log("[feed] Vulkan RTV mapping changed across flush; suppressing copy home");
+                done = false;
+            }
             // Take the images back from the D3D12 device: acquire from
             // VK_QUEUE_FAMILY_EXTERNAL, making the evaluate's output writes visible to
             // the copy home. This submit waits on the out-fence, so the acquire is
@@ -5663,6 +5728,7 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
             g.vk_released = false;
             if (done)
             {
+                FeedVkProbeVk(cb, 2, g.vk_img[SLOT_OUTPUT], VK_IMAGE_LAYOUT_GENERAL, g.vk_home_buf, g.home_pitch); // E
                 // Prefer the raw copy. vkCmdBlitImage converts, and that conversion is
                 // sRGB-aware: blitting our linear-typed output into a VK_FORMAT_*_SRGB
                 // swapchain applies a linear->sRGB encode and the frame comes back much
@@ -5683,6 +5749,12 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 else
                     FeedVkBlitImage(&g.vk, cb, g.vk_img[SLOT_OUTPUT], VK_IMAGE_LAYOUT_GENERAL,
                                     bb_img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, wh, h);
+                if (g_vk_probe.active)
+                {
+                    cl->barrier(bb_res, resource_usage::copy_dest, resource_usage::copy_source);
+                    FeedVkProbeVk(cb, 3, bb_img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL); // F: actual copy-home target
+                    cl->barrier(bb_res, resource_usage::copy_source, resource_usage::copy_dest);
+                }
             }
             {
                 const resource       res[1]  = { bb_res };
@@ -5690,6 +5762,12 @@ static void FeedFrameVk(reshade::api::effect_runtime *rt, reshade::api::command_
                 const resource_usage to[1]   = { resource_usage::render_target };
                 cl->barrier(1, res, from, to);
             }
+
+            if (g_cfg.vk_trace)
+                FeedVkIdentity(rt, cl, rtv, bb_res, n, capture_cb,
+                    FeedVkValue(g.vk_img[SLOT_COLOR]), FeedVkValue(g.vk_img[SLOT_OUTPUT]),
+                    g.tex12[SLOT_COLOR], g.tex12[SLOT_OUTPUT], n, wait_n, done);
+            FeedVkProbeEnd(done);
 
             // sync_home: submit the copy home and block until the GPU has finished it,
             // before this callback returns and the game presents. Everything else in this
@@ -6468,6 +6546,7 @@ static void ResolveHandles(reshade::api::effect_runtime *rt)
 // Only the overlay page stays, so the checkbox can undo it.
 static void OnInitEffectRuntime(reshade::api::effect_runtime *rt)
 {
+    if (g_cfg.enabled) FeedVkFramePresentInstall(rt);
     if (!g_cfg.enabled) return;
     RuntimeSlot *slot = TrackRuntime(rt);
     static int inits = 0;
@@ -6661,6 +6740,9 @@ static void OnDestroyDevice(reshade::api::device *dev)
     {
         Log("[feed] the game's Vulkan device is being destroyed; shutting the session down");
         g_ngx_dying = true;
+        // ReShade destroys its queue wrappers BEFORE emitting destroy_device.
+        // Vulkan requires the application to have retired work before this point.
+        g.rs_queue = nullptr;
         ShutdownSession();
     }
     else if (g.session_ready && dev->get_api() == reshade::api::device_api::opengl && dev == g.rs_dev)
@@ -7001,6 +7083,7 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
         reshade::unregister_event<reshade::addon_event::reshade_reloaded_effects>(OnReloadedEffects);
         reshade::unregister_event<reshade::addon_event::reshade_render_technique>(OnRenderTechnique);
         reshade::unregister_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
+        FeedVkFramePresentRemove();
         FeedVkHookRemove();   // before this code is unmapped -- ReShade reloads add-ons per Vulkan instance
         g_ngx_dying = true;   // process is exiting: never call back into NGX
         ShutdownSession();

--- a/src/feed_vk_present64.h
+++ b/src/feed_vk_present64.h
@@ -1,0 +1,115 @@
+// 64-bit feeder only. ReShade 6.8 attaches the game's present waits AFTER
+// present_effect_runtime returns. An add-on flushing inside a technique must
+// bring those dependencies forward before submitting any recorded effects.
+#pragma once
+#include "feed_vk_present_order.h"
+
+struct FeedVkPresentContext
+{
+    VkQueue queue;
+    const VkPresentInfoKHR *info;
+    bool ordered = false;
+    reshade::api::command_queue *graphics = nullptr;
+};
+static thread_local FeedVkPresentContext *g_vk_present_context;
+static PFN_vkQueuePresentKHR g_vk_frame_present_orig;
+static void *g_vk_frame_present_target;
+
+static VKAPI_ATTR VkResult VKAPI_CALL FeedVkFramePresent(VkQueue queue, const VkPresentInfoKHR *info)
+{
+    FeedVkPresentContext context = { queue, info };
+    struct Scope
+    {
+        FeedVkPresentContext *previous;
+        ~Scope() { g_vk_present_context = previous; }
+    } scope = { g_vk_present_context };
+    g_vk_present_context = &context;
+    return g_vk_frame_present_orig(queue, info);
+}
+
+static bool FeedVkFramePresentInstall(reshade::api::effect_runtime *rt)
+{
+    if (rt->get_device()->get_api() != reshade::api::device_api::vulkan) return true;
+    HMODULE loader = GetModuleHandleW(L"vulkan-1.dll");
+    const auto gdpa = loader ? reinterpret_cast<PFN_vkGetDeviceProcAddr>(GetProcAddress(loader, "vkGetDeviceProcAddr")) : nullptr;
+    void *target = gdpa ? reinterpret_cast<void *>(gdpa(FeedVkDispatch<VkDevice>(rt->get_device()->get_native()), "vkQueuePresentKHR")) : nullptr;
+    if (!target) return false;
+    if (g_vk_frame_present_target) return target == g_vk_frame_present_target;
+    // The device dispatch entry includes ReShade and catches engines bypassing
+    // the loader export used by the old, counting-only present hook.
+    MH_STATUS status = MH_Initialize();
+    if (status != MH_OK && status != MH_ERROR_ALREADY_INITIALIZED) return false;
+    status = MH_CreateHook(target, reinterpret_cast<void *>(&FeedVkFramePresent), reinterpret_cast<void **>(&g_vk_frame_present_orig));
+    if (status == MH_OK) status = MH_EnableHook(target);
+    if (status != MH_OK)
+    {
+        Log("[feed] Vulkan present dependency hook failed: %s", MH_StatusToString(status));
+        // Do not remove another owner's hook if CreateHook returned ALREADY_CREATED.
+        if (g_vk_frame_present_orig) MH_RemoveHook(target);
+        g_vk_frame_present_orig = nullptr;
+        return false;
+    }
+    g_vk_frame_present_target = target;
+    Log("[feed] Vulkan present dependency hook installed at device dispatch %p (detroit-sync.1)", target);
+    return true;
+}
+
+static void FeedVkFramePresentRemove()
+{
+    if (!g_vk_frame_present_target) return;
+    MH_DisableHook(g_vk_frame_present_target);
+    MH_RemoveHook(g_vk_frame_present_target);
+    g_vk_frame_present_target = nullptr;
+    g_vk_frame_present_orig = nullptr;
+}
+
+static int FeedVkPresentSlot(reshade::api::effect_runtime *rt)
+{
+    if (!g_vk_present_context || !g_vk_present_context->info) return -1;
+    const auto *info = g_vk_present_context->info;
+    for (uint32_t i = 0; i < info->swapchainCount; ++i)
+        if (FeedVkValue(info->pSwapchains[i]) == rt->get_native()) return static_cast<int>(i);
+    return -1;
+}
+
+// No raw QueueSubmit and no CPU drain. These calls run inside ReShade's present
+// queue locks. Wait ALL original binary semaphores before signal() can flush the
+// recorded effect list. Re-arm them once so ReShade's later present submission
+// can still consume its unchanged wait list. Timeline values are ignored for
+// binary semaphores by Vulkan. One gate per present, including multi-swapchain.
+static bool FeedVkOrderPresent(reshade::api::effect_runtime *rt, reshade::api::command_list *cl)
+{
+    const int slot = FeedVkPresentSlot(rt);
+    if (slot < 0 || cl != rt->get_command_queue()->get_immediate_command_list()) return false;
+    auto &context = *g_vk_present_context;
+    auto *queue = rt->get_command_queue();
+    if (context.ordered) return context.graphics == queue;
+    const auto *info = context.info;
+    if (!FeedVkWaitAndRearm(info->waitSemaphoreCount,
+        [&](uint32_t i) { return queue->wait({ FeedVkValue(info->pWaitSemaphores[i]) }, 0); },
+        [&](uint32_t i) { return queue->signal({ FeedVkValue(info->pWaitSemaphores[i]) }, 0); })) return false;
+    context.ordered = true;
+    context.graphics = queue;
+    return true;
+}
+
+static void FeedVkIdentity(reshade::api::effect_runtime *rt, reshade::api::command_list *cl,
+    reshade::api::resource_view rtv, reshade::api::resource captured, uint64_t frame, uint64_t cb_in,
+    uint64_t color_vk, uint64_t output_vk, const void *color12, const void *output12,
+    uint64_t in_value, uint64_t out_value, bool copied)
+{
+    const int slot = FeedVkPresentSlot(rt);
+    const uint32_t index = rt->get_current_back_buffer_index();
+    const uint32_t present_index = slot >= 0 ? g_vk_present_context->info->pImageIndices[slot] : UINT32_MAX;
+    const auto current = rt->get_back_buffer(index);
+    const auto presented = present_index < rt->get_back_buffer_count() ? rt->get_back_buffer(present_index) : reshade::api::resource {};
+    const auto home = rt->get_device()->get_resource_from_view(rtv);
+    Log("[feed] vk identity frame=%llu swap=%llx runtime_idx=%u present_idx=%u present_image=%llx current=%llx rtv=%llx capture=%llx home=%llx intermediate=%d stable=%d copied=%d color_vk=%llx output_vk=%llx color12=%p output12=%p gfx_q=%llx present_q=%llx cb_in=%llx cb_home=%llx in=%llu out=%llu waits=%u ordered=%d",
+        frame, rt->get_native(), index, present_index, presented.handle, current.handle, rtv.handle,
+        captured.handle, home.handle, captured != current, captured == home && index == present_index, copied,
+        color_vk, output_vk, color12, output12, rt->get_command_queue()->get_native(),
+        g_vk_present_context ? FeedVkValue(g_vk_present_context->queue) : 0,
+        cb_in, cl->get_native(), in_value, out_value,
+        g_vk_present_context ? g_vk_present_context->info->waitSemaphoreCount : 0,
+        g_vk_present_context && g_vk_present_context->ordered);
+}

--- a/src/feed_vk_present_order.h
+++ b/src/feed_vk_present_order.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+
+// signal() may flush recorded work. Queue every input dependency before any
+// signal, then restore the binary tokens expected by the caller's final present.
+template <typename Wait, typename Signal>
+static bool FeedVkWaitAndRearm(uint32_t count, Wait wait, Signal signal)
+{
+    for (uint32_t i = 0; i < count; ++i) if (!wait(i)) return false;
+    for (uint32_t i = 0; i < count; ++i) if (!signal(i)) return false;
+    return true;
+}

--- a/src/feed_vk_probe64.h
+++ b/src/feed_vk_probe64.h
@@ -1,0 +1,197 @@
+// Opt-in six-stage transport probe. Included after Feed and Barrier are defined.
+// Three 16x16 tiles, at 1/4, 1/2 and 3/4 of the image, read after BOTH APIs retire.
+// No hashes include undefined row padding. B/E follow the active image/buffer route.
+#pragma once
+static constexpr UINT kVkProbeSide = 16, kVkProbePitch = 256;
+static constexpr UINT kVkProbeTile = kVkProbeSide * kVkProbePitch;
+static constexpr UINT kVkProbeStage = 3 * kVkProbeTile;
+struct FeedVkProbe
+{
+    reshade::api::device *dev = nullptr;
+    reshade::api::resource read[4] = {}; // A, B, E, F
+    reshade::api::fence fence = {};
+    ID3D12Resource *d12 = nullptr;       // C, D
+    PFN_vkCmdCopyBuffer copy_buffer = nullptr;
+    uint64_t serial = 0, pending = 0, frame = 0, d12_fence = 0;
+    bool active = false, staged = false, intermediate = false, valid = false;
+    UINT color_bpp = 0, output_bpp = 0;
+} static g_vk_probe;
+
+static void FeedVkProbeRelease() // Caller has drained both APIs.
+{
+    if (g_vk_probe.dev)
+    {
+        for (auto res : g_vk_probe.read) if (res.handle) g_vk_probe.dev->destroy_resource(res);
+        if (g_vk_probe.fence.handle) g_vk_probe.dev->destroy_fence(g_vk_probe.fence);
+    }
+    SafeRelease(g_vk_probe.d12);
+    g_vk_probe = {};
+}
+
+static uint64_t FeedVkProbeHash(const uint8_t *p, UINT bpp, bool *uniform)
+{
+    uint64_t hash = 1469598103934665603ull;
+    *uniform = true;
+    for (UINT tile = 0; tile < 3; ++tile)
+        for (UINT y = 0; y < kVkProbeSide; ++y)
+            for (UINT x = 0; x < kVkProbeSide * bpp; ++x)
+            {
+                const auto byte = p[tile * kVkProbeTile + y * kVkProbePitch + x];
+                hash = (hash ^ byte) * 1099511628211ull;
+                *uniform &= byte == p[x % bpp];
+            }
+    return hash;
+}
+
+static void FeedVkProbeAnalyse()
+{
+    auto &p = g_vk_probe;
+    if (!p.pending || p.dev->get_completed_fence_value(p.fence) < p.pending ||
+        g.fence12->GetCompletedValue() < p.d12_fence) return;
+    if (!p.valid) { p.pending = 0; return; }
+    uint64_t hash[6] = {};
+    bool uniform[6] = {}, valid = true;
+    const int stages[4] = { 0, 1, 4, 5 };
+    for (int i = 0; i < 4; ++i)
+    {
+        void *data = nullptr;
+        if (!p.dev->map_buffer_region(p.read[i], 0, kVkProbeStage, reshade::api::map_access::read_only, &data) || !data)
+        { valid = false; continue; }
+        const UINT bpp = i < 2 || i == 3 ? p.color_bpp : p.output_bpp;
+        hash[stages[i]] = FeedVkProbeHash(static_cast<const uint8_t *>(data), bpp, &uniform[stages[i]]);
+        p.dev->unmap_buffer_region(p.read[i]);
+    }
+    void *data = nullptr;
+    const D3D12_RANGE range = { 0, 2 * kVkProbeStage }, none = { 0, 0 };
+    if (SUCCEEDED(p.d12->Map(0, &range, &data)) && data)
+    {
+        hash[2] = FeedVkProbeHash(static_cast<const uint8_t *>(data), p.color_bpp, &uniform[2]);
+        hash[3] = FeedVkProbeHash(static_cast<const uint8_t *>(data) + kVkProbeStage, p.output_bpp, &uniform[3]);
+        p.d12->Unmap(0, &none);
+    }
+    else valid = false;
+    Log("[feed] vk stages frame=%llu valid=%d route=%s F=%s A=%016llx B=%016llx C=%016llx D=%016llx E=%016llx F=%016llx uniform=%d%d%d%d%d%d bpp=%u/%u (3 tiles; C before evaluate, D after)",
+        p.frame, valid, p.staged ? "buffer" : "image", p.intermediate ? "effect-target" : "swapchain",
+        hash[0], hash[1], hash[2], hash[3], hash[4], hash[5],
+        uniform[0], uniform[1], uniform[2], uniform[3], uniform[4], uniform[5], p.color_bpp, p.output_bpp);
+    p.pending = 0;
+}
+
+static void FeedVkProbeBegin(reshade::api::effect_runtime *rt, reshade::api::resource target)
+{
+    auto &p = g_vk_probe;
+    FeedVkProbeAnalyse();
+    p.active = false;
+    // The historical-output diagnostics deliberately mix frame n and n-1. Do not
+    // publish a six-stage same-frame comparison for those modes or half copies.
+    if (!g_cfg.vk_trace || g_cfg.mode < 2 || g_cfg.async_home || g_cfg.half_home ||
+        p.pending || ((g.vk_frame + 1) % 60) != 0 || g.width < 64 || g.height < 64) return;
+    const UINT cb = StaleProbeTexelBytes(g.color_fmt), ob = StaleProbeTexelBytes(g.output_fmt);
+    if (!cb || !ob || cb * kVkProbeSide > kVkProbePitch || ob * kVkProbeSide > kVkProbePitch) return;
+    if (!p.dev)
+    {
+        p.dev = rt->get_device();
+        for (auto &res : p.read)
+        {
+            // ReShade's Vulkan map does not invalidate noncoherent allocations.
+            // Its upload heap REQUIRES HOST_COHERENT; readback only prefers cached.
+            // Vulkan allows transfer destinations in upload memory. These tiny
+            // diagnostic buffers favour correct CPU visibility over read speed.
+            const reshade::api::resource_desc desc(kVkProbeStage, reshade::api::memory_heap::upload, reshade::api::resource_usage::copy_dest);
+            if (!p.dev->create_resource(desc, nullptr, reshade::api::resource_usage::copy_dest, &res))
+            { FeedVkProbeRelease(); return; }
+        }
+        if (!p.dev->create_fence(0, reshade::api::fence_flags::none, &p.fence))
+        { FeedVkProbeRelease(); return; }
+        D3D12_HEAP_PROPERTIES hp = {}; hp.Type = D3D12_HEAP_TYPE_READBACK;
+        D3D12_RESOURCE_DESC rd = {}; rd.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        rd.Width = 2 * kVkProbeStage; rd.Height = 1; rd.DepthOrArraySize = 1;
+        rd.MipLevels = 1; rd.SampleDesc.Count = 1; rd.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        if (FAILED(g.dev12->CreateCommittedResource(&hp, D3D12_HEAP_FLAG_NONE, &rd, D3D12_RESOURCE_STATE_COPY_DEST,
+            nullptr, __uuidof(ID3D12Resource), reinterpret_cast<void **>(&p.d12))))
+        { FeedVkProbeRelease(); return; }
+        p.copy_buffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(g.vk.GetDeviceProcAddr(g.vk.dev, "vkCmdCopyBuffer"));
+        if (!p.copy_buffer) { FeedVkProbeRelease(); return; }
+    }
+    p.active = true;
+    p.frame = g.vk_frame + 1;
+    p.color_bpp = cb; p.output_bpp = ob;
+    p.staged = g.vk_in_buf[SLOT_COLOR] != VK_NULL_HANDLE;
+    p.intermediate = target != rt->get_current_back_buffer();
+}
+
+static void FeedVkProbeVk(VkCommandBuffer command, int stage, VkImage image, VkImageLayout layout,
+    VkBuffer buffer = VK_NULL_HANDLE, UINT row_pitch = 0)
+{
+    auto &p = g_vk_probe;
+    if (!p.active) return;
+    const UINT bpp = stage == 2 ? p.output_bpp : p.color_bpp;
+    const VkBuffer dest = FeedVkHandle<VkBuffer>(p.read[stage].handle);
+    if (buffer)
+    {
+        VkBufferCopy copies[3 * kVkProbeSide] = {};
+        for (UINT t = 0; t < 3; ++t)
+            for (UINT y = 0; y < kVkProbeSide; ++y)
+            {
+                auto &copy = copies[t * kVkProbeSide + y];
+                copy.srcOffset = VkDeviceSize(g.height * (t + 1) / 4 - kVkProbeSide / 2 + y) * row_pitch +
+                    VkDeviceSize(g.width * (t + 1) / 4 - kVkProbeSide / 2) * bpp;
+                copy.dstOffset = t * kVkProbeTile + y * kVkProbePitch;
+                copy.size = kVkProbeSide * bpp;
+            }
+        p.copy_buffer(command, buffer, dest, 3 * kVkProbeSide, copies);
+    }
+    else
+    {
+        VkBufferImageCopy copies[3] = {};
+        for (UINT t = 0; t < 3; ++t)
+        {
+            auto &copy = copies[t];
+            copy.bufferOffset = t * kVkProbeTile; copy.bufferRowLength = kVkProbePitch / bpp;
+            copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+            copy.imageOffset = { int(g.width * (t + 1) / 4 - kVkProbeSide / 2), int(g.height * (t + 1) / 4 - kVkProbeSide / 2), 0 };
+            copy.imageExtent = { kVkProbeSide, kVkProbeSide, 1 };
+        }
+        g.vk.CmdCopyImageToBuffer(command, image, layout, dest, 3, copies);
+    }
+}
+
+static void FeedVkProbeD12(bool output)
+{
+    if (!g_vk_probe.active) return;
+    auto *resource = g.tex12[output ? SLOT_OUTPUT : SLOT_COLOR];
+    const auto state = output ? D3D12_RESOURCE_STATE_UNORDERED_ACCESS : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    Barrier(resource, state, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    D3D12_TEXTURE_COPY_LOCATION src = {}; src.pResource = resource; src.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    D3D12_TEXTURE_COPY_LOCATION dst = {}; dst.pResource = g_vk_probe.d12; dst.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    for (UINT t = 0; t < 3; ++t)
+    {
+        const UINT x = g.width * (t + 1) / 4 - kVkProbeSide / 2, y = g.height * (t + 1) / 4 - kVkProbeSide / 2;
+        const D3D12_BOX box = { x, y, 0, x + kVkProbeSide, y + kVkProbeSide, 1 };
+        dst.PlacedFootprint.Offset = (output ? kVkProbeStage : 0) + t * kVkProbeTile;
+        dst.PlacedFootprint.Footprint = { output ? g.output_fmt : g.color_fmt, kVkProbeSide, kVkProbeSide, 1, kVkProbePitch };
+        g.list->CopyTextureRegion(&dst, 0, 0, 0, &src, &box);
+    }
+    Barrier(resource, D3D12_RESOURCE_STATE_COPY_SOURCE, state);
+}
+
+static void FeedVkProbeEnd(bool done)
+{
+    auto &p = g_vk_probe;
+    if (!p.active) return;
+    p.active = false;
+    VkMemoryBarrier host = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
+    host.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    host.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+    const auto cb = FeedVkDispatch<VkCommandBuffer>(g.rs_queue->get_immediate_command_list()->get_native());
+    g.vk.CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT,
+        0, 1, &host, 0, nullptr, 0, nullptr);
+    // Extra flush once per sample, only with vk_trace=1. Never map unretired work.
+    const uint64_t serial = ++p.serial;
+    if (g.rs_queue->signal(p.fence, serial))
+    {
+        p.pending = serial;
+        p.d12_fence = g.fence_value;
+        p.valid = done;
+    }
+}

--- a/tests/test-vk-present-order.bat
+++ b/tests/test-vk-present-order.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+cd /d "%~dp0.."
+call tools\vcvars.bat x64 || exit /b 1
+if not exist build mkdir build
+cl /nologo /EHsc /W4 /std:c++20 /Iexternal\vulkan tests\vk-present-order.cpp /Fobuild\ /Febuild\vk-present-order.exe || exit /b 1
+build\vk-present-order.exe
+exit /b %errorlevel%

--- a/tests/vk-present-order.cpp
+++ b/tests/vk-present-order.cpp
@@ -1,0 +1,169 @@
+// Deterministic GPU regression for an early effect flush bypassing present waits.
+// Needs Vulkan 1.2, two queues and host-coherent memory; no game or NGX needed.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#define VK_NO_PROTOTYPES
+#include <vulkan/vulkan.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include "../src/feed_vk_present_order.h"
+
+static void check(VkResult r) { if (r != VK_SUCCESS) { std::printf("Vulkan failure %d\n", r); std::exit(1); } }
+static void require(bool b, const char *what) { if (!b) { std::printf("FAIL: %s\n", what); std::exit(1); } }
+#define FN(name) PFN_vk##name name
+
+int main()
+{
+    HMODULE loader = LoadLibraryW(L"vulkan-1.dll");
+    require(loader != nullptr, "Vulkan loader");
+    auto gipa = reinterpret_cast<PFN_vkGetInstanceProcAddr>(GetProcAddress(loader, "vkGetInstanceProcAddr"));
+    auto CreateInstance = reinterpret_cast<PFN_vkCreateInstance>(gipa(nullptr, "vkCreateInstance"));
+    VkApplicationInfo app = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
+    app.pApplicationName = "feeder-present-order-test"; app.apiVersion = VK_API_VERSION_1_2;
+    VkInstanceCreateInfo ici = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO }; ici.pApplicationInfo = &app;
+    const char *instance_ext = VK_KHR_SURFACE_EXTENSION_NAME;
+    ici.enabledExtensionCount = 1; ici.ppEnabledExtensionNames = &instance_ext;
+    VkInstance instance; check(CreateInstance(&ici, nullptr, &instance));
+#define INSTANCE(name) auto name = reinterpret_cast<PFN_vk##name>(gipa(instance, "vk" #name)); require(name != nullptr, #name)
+    INSTANCE(EnumeratePhysicalDevices); INSTANCE(GetPhysicalDeviceQueueFamilyProperties);
+    INSTANCE(GetPhysicalDeviceMemoryProperties); INSTANCE(GetPhysicalDeviceProperties);
+    INSTANCE(CreateDevice); INSTANCE(GetDeviceProcAddr); INSTANCE(DestroyInstance);
+    uint32_t count = 0; check(EnumeratePhysicalDevices(instance, &count, nullptr));
+    require(count != 0, "physical device");
+    std::vector<VkPhysicalDevice> devices(count); check(EnumeratePhysicalDevices(instance, &count, devices.data()));
+    VkPhysicalDevice phys = devices[0];
+    VkPhysicalDeviceProperties props; GetPhysicalDeviceProperties(phys, &props);
+    std::printf("GPU: %s\n", props.deviceName);
+    GetPhysicalDeviceQueueFamilyProperties(phys, &count, nullptr);
+    std::vector<VkQueueFamilyProperties> families(count); GetPhysicalDeviceQueueFamilyProperties(phys, &count, families.data());
+    uint32_t family = UINT32_MAX;
+    for (uint32_t i = 0; i < count; ++i)
+        if (families[i].queueCount >= 2 && (families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) { family = i; break; }
+    require(family != UINT32_MAX, "two graphics queues");
+    float priorities[2] = { 1, 1 };
+    VkDeviceQueueCreateInfo qci = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
+    qci.queueFamilyIndex = family; qci.queueCount = 2; qci.pQueuePriorities = priorities;
+    VkPhysicalDeviceTimelineSemaphoreFeatures feature = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES };
+    feature.timelineSemaphore = VK_TRUE;
+    VkDeviceCreateInfo dci = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO }; dci.pNext = &feature;
+    const char *device_ext = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+    dci.enabledExtensionCount = 1; dci.ppEnabledExtensionNames = &device_ext;
+    dci.queueCreateInfoCount = 1; dci.pQueueCreateInfos = &qci;
+    VkDevice dev; check(CreateDevice(phys, &dci, nullptr, &dev));
+    const auto present = GetDeviceProcAddr(dev, "vkQueuePresentKHR");
+    HMODULE present_module = nullptr;
+    GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        reinterpret_cast<LPCSTR>(present), &present_module);
+    char module_path[MAX_PATH] = {}; GetModuleFileNameA(present_module, module_path, MAX_PATH);
+    std::printf("Present dispatch: %p in %s; same as loader export=%d\n", reinterpret_cast<void *>(present), module_path,
+        present == reinterpret_cast<PFN_vkVoidFunction>(GetProcAddress(loader, "vkQueuePresentKHR")));
+#define DEVICE(name) auto name = reinterpret_cast<PFN_vk##name>(GetDeviceProcAddr(dev, "vk" #name)); require(name != nullptr, #name)
+    DEVICE(GetDeviceQueue); DEVICE(CreateBuffer); DEVICE(GetBufferMemoryRequirements); DEVICE(AllocateMemory);
+    DEVICE(BindBufferMemory); DEVICE(MapMemory); DEVICE(UnmapMemory); DEVICE(DestroyBuffer); DEVICE(FreeMemory);
+    DEVICE(CreateCommandPool); DEVICE(AllocateCommandBuffers); DEVICE(BeginCommandBuffer); DEVICE(EndCommandBuffer);
+    DEVICE(CmdFillBuffer); DEVICE(CmdCopyBuffer); DEVICE(CmdPipelineBarrier); DEVICE(QueueSubmit);
+    DEVICE(CreateSemaphore); DEVICE(SignalSemaphore); DEVICE(DestroySemaphore); DEVICE(CreateFence);
+    DEVICE(WaitForFences); DEVICE(ResetFences); DEVICE(DestroyFence); DEVICE(DeviceWaitIdle);
+    DEVICE(DestroyCommandPool); DEVICE(DestroyDevice); DEVICE(ResetCommandPool);
+    VkQueue producer, graphics; GetDeviceQueue(dev, family, 0, &producer); GetDeviceQueue(dev, family, 1, &graphics);
+    VkPhysicalDeviceMemoryProperties memory; GetPhysicalDeviceMemoryProperties(phys, &memory);
+    VkBuffer buffers[2]; VkDeviceMemory allocations[2]; uint32_t *mapped[2];
+    for (int i = 0; i < 2; ++i)
+    {
+        VkBufferCreateInfo bci = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO }; bci.size = 4;
+        bci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        check(CreateBuffer(dev, &bci, nullptr, &buffers[i]));
+        VkMemoryRequirements req; GetBufferMemoryRequirements(dev, buffers[i], &req);
+        uint32_t type = UINT32_MAX;
+        for (uint32_t t = 0; t < memory.memoryTypeCount; ++t)
+            if ((req.memoryTypeBits & (1u << t)) && (memory.memoryTypes[t].propertyFlags &
+                (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) ==
+                (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) { type = t; break; }
+        require(type != UINT32_MAX, "coherent host memory");
+        VkMemoryAllocateInfo mai = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO }; mai.allocationSize = req.size; mai.memoryTypeIndex = type;
+        check(AllocateMemory(dev, &mai, nullptr, &allocations[i]));
+        check(BindBufferMemory(dev, buffers[i], allocations[i], 0));
+        check(MapMemory(dev, allocations[i], 0, VK_WHOLE_SIZE, 0, reinterpret_cast<void **>(&mapped[i])));
+    }
+    VkCommandPoolCreateInfo pci = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO }; pci.queueFamilyIndex = family;
+    VkCommandPool pool; check(CreateCommandPool(dev, &pci, nullptr, &pool));
+    VkCommandBufferAllocateInfo cai = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO }; cai.commandPool = pool;
+    cai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY; cai.commandBufferCount = 2;
+    VkCommandBuffer cmds[2]; check(AllocateCommandBuffers(dev, &cai, cmds));
+    VkFenceCreateInfo fci = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO }; VkFence fence;
+    check(CreateFence(dev, &fci, nullptr, &fence));
+    VkSemaphoreTypeCreateInfo sti = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO }; sti.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+    VkSemaphoreCreateInfo sci = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO }; sci.pNext = &sti;
+    VkSemaphore release; check(CreateSemaphore(dev, &sci, nullptr, &release)); sci.pNext = nullptr;
+    VkSemaphore ready[2]; for (auto &sem : ready) check(CreateSemaphore(dev, &sci, nullptr, &sem));
+    uint64_t serial = 0;
+    for (int repetition = 0; repetition < 8; ++repetition)
+    for (int mode = 0; mode < 3; ++mode) // deferred, broken early flush, fixed early flush
+    {
+        ++serial;
+        *mapped[0] = 0x11111111; *mapped[1] = 0;
+        const uint32_t fresh = 0x22220000 | static_cast<uint32_t>(serial);
+        VkCommandBufferBeginInfo begin = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+        check(BeginCommandBuffer(cmds[0], &begin)); CmdFillBuffer(cmds[0], buffers[0], 0, 4, fresh); check(EndCommandBuffer(cmds[0]));
+        check(BeginCommandBuffer(cmds[1], &begin));
+        VkBufferCopy copy = { 0, 0, 4 }; CmdCopyBuffer(cmds[1], buffers[0], buffers[1], 1, &copy);
+        VkMemoryBarrier host = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
+        host.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT; host.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+        CmdPipelineBarrier(cmds[1], VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0, 1, &host, 0, nullptr, 0, nullptr);
+        check(EndCommandBuffer(cmds[1]));
+        const VkPipelineStageFlags stages[2] = { VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT };
+        VkTimelineSemaphoreSubmitInfo timeline = { VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+        timeline.waitSemaphoreValueCount = 1; timeline.pWaitSemaphoreValues = &serial;
+        VkSubmitInfo produce = { VK_STRUCTURE_TYPE_SUBMIT_INFO }; produce.pNext = &timeline;
+        produce.waitSemaphoreCount = 1; produce.pWaitSemaphores = &release; produce.pWaitDstStageMask = stages;
+        produce.commandBufferCount = 1; produce.pCommandBuffers = &cmds[0]; produce.signalSemaphoreCount = 2; produce.pSignalSemaphores = ready;
+        check(QueueSubmit(producer, 1, &produce, VK_NULL_HANDLE));
+        auto flush = [&](VkFence done) {
+            VkSubmitInfo submit = { VK_STRUCTURE_TYPE_SUBMIT_INFO }; submit.commandBufferCount = 1; submit.pCommandBuffers = &cmds[1];
+            check(QueueSubmit(graphics, 1, &submit, done));
+        };
+        if (mode == 1)
+        {
+            flush(fence);
+            check(WaitForFences(dev, 1, &fence, VK_TRUE, 5000000000ull));
+            require(*mapped[1] == 0x11111111, "negative control must capture stale source");
+            check(ResetFences(dev, 1, &fence));
+        }
+        if (mode == 2)
+        {
+            bool flushed = false;
+            require(FeedVkWaitAndRearm(2, [&](uint32_t i) {
+                uint64_t value = 0;
+                VkTimelineSemaphoreSubmitInfo values = { VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+                values.waitSemaphoreValueCount = 1; values.pWaitSemaphoreValues = &value;
+                VkSubmitInfo submit = { VK_STRUCTURE_TYPE_SUBMIT_INFO }; submit.pNext = &values;
+                submit.waitSemaphoreCount = 1; submit.pWaitSemaphores = &ready[i]; submit.pWaitDstStageMask = stages;
+                return QueueSubmit(graphics, 1, &submit, VK_NULL_HANDLE) == VK_SUCCESS;
+            }, [&](uint32_t i) {
+                if (!flushed) { flush(VK_NULL_HANDLE); flushed = true; }
+                uint64_t value = 0;
+                VkTimelineSemaphoreSubmitInfo values = { VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO };
+                values.signalSemaphoreValueCount = 1; values.pSignalSemaphoreValues = &value;
+                VkSubmitInfo submit = { VK_STRUCTURE_TYPE_SUBMIT_INFO }; submit.pNext = &values;
+                submit.signalSemaphoreCount = 1; submit.pSignalSemaphores = &ready[i];
+                return QueueSubmit(graphics, 1, &submit, VK_NULL_HANDLE) == VK_SUCCESS;
+            }), "gate submits");
+        }
+        VkSubmitInfo final = { VK_STRUCTURE_TYPE_SUBMIT_INFO };
+        final.waitSemaphoreCount = 2; final.pWaitSemaphores = ready; final.pWaitDstStageMask = stages;
+        if (mode == 0) { final.commandBufferCount = 1; final.pCommandBuffers = &cmds[1]; }
+        check(QueueSubmit(graphics, 1, &final, fence));
+        require(WaitForFences(dev, 1, &fence, VK_TRUE, 1000000) == VK_TIMEOUT, "must wait for producer");
+        VkSemaphoreSignalInfo release_info = { VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO }; release_info.semaphore = release; release_info.value = serial;
+        check(SignalSemaphore(dev, &release_info));
+        check(WaitForFences(dev, 1, &fence, VK_TRUE, 5000000000ull));
+        require(*mapped[1] == (mode == 1 ? 0x11111111 : fresh), "captured frame contents");
+        check(DeviceWaitIdle(dev)); check(ResetFences(dev, 1, &fence)); check(ResetCommandPool(dev, pool, 0));
+    }
+    std::puts("PASS: deferred=8 fresh; ungated early flush=8 stale; gated early flush=8 fresh; final binary waits all retire");
+    for (auto sem : ready) DestroySemaphore(dev, sem, nullptr); DestroySemaphore(dev, release, nullptr);
+    DestroyFence(dev, fence, nullptr); DestroyCommandPool(dev, pool, nullptr);
+    for (int i = 0; i < 2; ++i) { UnmapMemory(dev, allocations[i]); DestroyBuffer(dev, buffers[i], nullptr); FreeMemory(dev, allocations[i], nullptr); }
+    DestroyDevice(dev, nullptr); DestroyInstance(instance, nullptr); FreeLibrary(loader);
+}


### PR DESCRIPTION
Detroit's 64-bit Vulkan mode=2 path can capture the backbuffer before the game's render work completes: it flushes inside the ReShade technique callback, whereas ReShade 6.8 attaches the game's present wait semaphores after effects return. Mode=1 does not take that early-submit path, and advancing feeder fences cannot repair the missing dependency.

This patch queues the original present waits before the first early flush, then re-signals the binary semaphores so ReShade's later wait list remains valid. It captures context at device-dispatch vkQueuePresentKHR and keeps the callback RTV as the copy-home target, including legitimate ReShade intermediate images. Vulkan imports are also retired before destruction.

Includes optional per-frame resource identity logging and A-F transport probes, plus a deterministic two-queue GPU regression. The reported stale hash 5f9eb3fedcef8383 matches an opaque-black 64x64 RGBA8/BGRA8 tile, so the new probe samples three locations and captures D3D12 COLOR before evaluation. Passthrough no longer silently runs NGX when formats differ.

Validation:
- Reporter confirmed the patched beta.2 build works in Detroit, with Smooth Motion disabled (RTX 4070 SUPER, driver 616.56). Exact test duration/settings beyond the original report were not recorded.
- x64 MSVC build passes.
- On the same GPU/driver, eight iterations each: deferred submission captures fresh data, unguarded early submission captures stale data, gated early submission captures fresh data. All final binary waits retire and are reused across frames.
- DOOM 2016 regression and the full diagnostic matrix remain outstanding.

Targets v0.14.0. No 32-bit code or shared Vulkan headers changed. The patch was developed with OpenAI Codex; the in-game validation was performed by the reporter.

Related to #13, specifically the reproduction with Smooth Motion disabled. See INVESTIGATION-DETROIT64.md for source references and reproduction steps.