### PR TITLE
Add opt-in source-guided SDR colour refinement

### DIFF
--- a/shaders/SourceGuidedColor.fx
+++ b/shaders/SourceGuidedColor.fx
@@ -1,0 +1,179 @@
+// Source-guided Color Refinement B++ -- local AI-assisted prototype.
+// Required order: SourceGuided_Save -> DLSS5_Feed -> SourceGuided_Apply.
+// No closed NR changes, extra NGX evaluation, fixed UI colours or screen boxes.
+// Oklab coefficients: https://bottosson.github.io/posts/oklab/ (public domain).
+// FX resource/sampler/pass semantics:
+// https://github.com/crosire/reshade-shaders/blob/slim/REFERENCE.md
+// Tested compiler target: ReShade 6.8.0, commit 18deaa52de0c425a78b329e9cb3c497281cd00ec.
+// Compile-off removes ALL resources and passes. Runtime bypass retains their cost.
+#ifndef SOURCE_GUIDED_COLOR
+#define SOURCE_GUIDED_COLOR 0
+#endif
+
+#if SOURCE_GUIDED_COLOR == 1 && __RENDERER__ >= 0xb000 && __RENDERER__ < 0xc000 && BUFFER_COLOR_SPACE == 1 && BUFFER_COLOR_BIT_DEPTH == 8
+
+uniform uint SGCR_Frame < source = "framecount"; >;
+uniform bool SGCR_Bypass < source = "key"; keycode = 118; mode = "toggle"; >;
+uniform bool SGCR_Enabled <
+    ui_label = "Enable source-guided colours";
+    ui_tooltip = "SDR sRGB prototype. F7 temporarily bypasses refinement only; F6 remains NR. Both techniques must surround DLSS5_Feed.";
+> = false;
+uniform float SGCR_Strength <
+    ui_type = "slider"; ui_label = "Colour separation";
+    ui_min = 0.0; ui_max = 1.0; ui_step = 0.01;
+    ui_tooltip = "0: neural output. 0.90: selected B++. Can also attenuate useful broad NR colour changes.";
+> = 0.9;
+uniform float SGCR_Tone <
+    ui_type = "slider"; ui_label = "Tone and contrast correction";
+    ui_min = 0.0; ui_max = 1.0; ui_step = 0.01;
+    ui_tooltip = "Affects the lightness base of every colour, not just white text.";
+> = 1.0;
+uniform float SGCR_Detail <
+    ui_type = "slider"; ui_label = "Neural residual detail";
+    ui_min = 0.0; ui_max = 2.0; ui_step = 0.01;
+    ui_tooltip = "1.00 preserves the neural residual. Larger values can amplify noise and halos.";
+> = 1.0;
+uniform int SGCR_View <
+    ui_type = "combo"; ui_label = "Comparison view";
+    ui_items = "Processed\0Source before Feeder\0Neural / post Feeder\0";
+> = 0;
+
+texture SourceGuided_Color : COLOR;
+texture SourceGuided_SourceLab { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA32F; };
+texture SourceGuided_NeuralLab { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA32F; };
+sampler SGCR_Color {
+    Texture = SourceGuided_Color; AddressU = Clamp; AddressV = Clamp;
+    MinFilter = Point; MagFilter = Point; MipFilter = Point; SRGBTexture = false;
+};
+sampler SGCR_Source {
+    Texture = SourceGuided_SourceLab; AddressU = Clamp; AddressV = Clamp;
+    MinFilter = Point; MagFilter = Point; MipFilter = Point; SRGBTexture = false;
+};
+sampler SGCR_Neural {
+    Texture = SourceGuided_NeuralLab; AddressU = Clamp; AddressV = Clamp;
+    MinFilter = Point; MagFilter = Point; MipFilter = Point; SRGBTexture = false;
+};
+
+void SGCR_VS(uint id : SV_VertexID, out float4 pos : SV_Position, out float2 uv : TEXCOORD) {
+    uv = float2((id << 1) & 2, id & 2);
+    pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}
+
+float3 SGCR_ToLab(float3 rgb) {
+    // Encoded sRGB is converted exactly once; samplers and writes are non-sRGB.
+    float3 hi = pow((saturate(rgb) + 0.055) / 1.055, 2.4);
+    float3 lin = float3(rgb.r <= 0.04045 ? rgb.r/12.92 : hi.r,
+                        rgb.g <= 0.04045 ? rgb.g/12.92 : hi.g,
+                        rgb.b <= 0.04045 ? rgb.b/12.92 : hi.b);
+    float3 lms = float3(dot(lin, float3(.4122214708, .5363325363, .0514459929)),
+                        dot(lin, float3(.2119034982, .6806995451, .1073969566)),
+                        dot(lin, float3(.0883024619, .2817188376, .6299787005)));
+    lms = pow(max(lms, 0.0), 1.0/3.0);
+    return float3(dot(lms, float3(.2104542553, .7936177850, -.0040720468)),
+                  dot(lms, float3(1.9779984951, -2.4285922050, .4505937099)),
+                  dot(lms, float3(.0259040371, .7827717662, -.8086757660)));
+}
+
+float3 SGCR_ToLinear(float3 lab) {
+    // Inverses of the exact matrices used by the existing CPU reference.
+    float3 lms = float3(dot(lab, float3(.999999998450520, .396337792173768, .215803758060759)),
+                        dot(lab, float3(1.000000008881761, -.105561342323656, -.063854174771706)),
+                        dot(lab, float3(1.000000054672411, -.089484182094966, -1.291485537864092)));
+    lms = lms*lms*lms;
+    return float3(dot(lms, float3(4.076741661347994, -3.307711590408193, .230969928729428)),
+                  dot(lms, float3(-1.268438004092176, 2.609757400663371, -.341319396310220)),
+                  dot(lms, float3(-.004196086541837, -.703418614459450, 1.707614700930945)));
+}
+
+float3 SGCR_Encode(float3 lin) {
+    lin = saturate(lin);
+    float3 hi = 1.055 * pow(lin, 1.0/2.4) - .055;
+    return float3(lin.r <= .0031308 ? lin.r*12.92 : hi.r,
+                  lin.g <= .0031308 ? lin.g*12.92 : hi.g,
+                  lin.b <= .0031308 ? lin.b*12.92 : hi.b);
+}
+
+bool SGCR_Fits(float3 lin) {
+    return all(lin >= -1e-9) && all(lin <= 1.0 + 1e-9);
+}
+
+float3 SGCR_Compress(float3 lab) {
+    lab.x = saturate(lab.x);
+    float3 lin = SGCR_ToLinear(lab);
+    if (SGCR_Fits(lin)) return SGCR_Encode(lin);
+    float low = 0.0, high = 1.0;
+    [loop] for (int i = 0; i < 16; ++i) {
+        float mid = (low + high) * .5;
+        if (SGCR_Fits(SGCR_ToLinear(float3(lab.x, lab.yz * mid)))) low = mid;
+        else high = mid;
+    }
+    return SGCR_Encode(SGCR_ToLinear(float3(lab.x, lab.yz * low)));
+}
+
+float4 SGCR_SavePS(float4 pos : SV_Position, float2 uv : TEXCOORD) : SV_Target {
+    // A zero/uninitialised target is invalid. Exact float32 integer stamps avoid
+    // modulo wrap accepting a stale source. Beyond this range, fail closed.
+    float stamp = SGCR_Frame <= 16777214u ? float(SGCR_Frame + 1u) : 0.0;
+    return float4(SGCR_ToLab(tex2D(SGCR_Color, uv).rgb), stamp);
+}
+
+float4 SGCR_NeuralPS(float4 pos : SV_Position, float2 uv : TEXCOORD) : SV_Target {
+    float4 neural = tex2D(SGCR_Color, uv);
+    return float4(SGCR_ToLab(neural.rgb), neural.a);
+}
+
+float4 SGCR_ApplyPS(float4 pos : SV_Position, float2 uv : TEXCOORD) : SV_Target {
+    float4 originalNeural = tex2D(SGCR_Color, uv);
+    if (!SGCR_Enabled || SGCR_Bypass || SGCR_View == 2 ||
+        (SGCR_Strength <= 0.0 && SGCR_View != 1)) return originalNeural;
+    float4 source = tex2D(SGCR_Source, uv);
+    if (SGCR_Frame > 16777214u || source.a != float(SGCR_Frame + 1u)) return originalNeural;
+    if (SGCR_View == 1) return float4(SGCR_Encode(SGCR_ToLinear(source.rgb)), originalNeural.a);
+
+    float3 neural = tex2D(SGCR_Neural, uv).rgb;
+    float3 sourceSum = 0.0, neuralSum = 0.0;
+    float weightSum = 0.0;
+    const float2 pixel = float2(1.0 / BUFFER_WIDTH, 1.0 / BUFFER_HEIGHT);
+    // Exact radius-4 joint bilateral B++ reference, not separable approximation.
+    [loop] for (int dy = -4; dy <= 4; ++dy) {
+        [loop] for (int dx = -4; dx <= 4; ++dx) {
+            float2 at = uv + float2(dx, dy) * pixel;
+            float3 sampleSource = tex2Dlod(SGCR_Source, float4(at, 0, 0)).rgb;
+            float3 delta = sampleSource - source.rgb;
+            float distance = delta.x*delta.x / .01 + dot(delta.yz, delta.yz) / .003025;
+            distance += float(dx*dx + dy*dy) / 6.76; // (4 * .65)^2
+            float weight = exp(-.5 * distance);
+            sourceSum += sampleSource * weight;
+            neuralSum += tex2Dlod(SGCR_Neural, float4(at, 0, 0)).rgb * weight;
+            weightSum += weight;
+        }
+    }
+    float3 sourceBase = sourceSum / weightSum;
+    float3 neuralBase = neuralSum / weightSum;
+    float strength = saturate(SGCR_Strength);
+    float3 correction = sourceBase - neuralBase;
+    correction.x *= saturate(SGCR_Tone);
+    float3 outputLab = neural + strength * correction;
+    outputLab += strength * (clamp(SGCR_Detail, 0.0, 2.0) - 1.0) * (neural - neuralBase);
+    return float4(SGCR_Compress(outputLab), originalNeural.a);
+}
+
+technique SourceGuided_Save < ui_label = "Source colours: BEFORE Feeder"; > {
+    pass SaveOriginalColourAreas {
+        VertexShader = SGCR_VS; PixelShader = SGCR_SavePS;
+        RenderTarget = SourceGuided_SourceLab;
+        SRGBWriteEnable = false;
+    }
+}
+technique SourceGuided_Apply < ui_label = "Source-guided colours: AFTER Feeder"; > {
+    pass ReadNeuralColourAreas {
+        VertexShader = SGCR_VS; PixelShader = SGCR_NeuralPS;
+        RenderTarget = SourceGuided_NeuralLab;
+        SRGBWriteEnable = false;
+    }
+    pass RefineColourAreasAndDetails {
+        VertexShader = SGCR_VS; PixelShader = SGCR_ApplyPS;
+        SRGBWriteEnable = false;
+    }
+}
+#endif

--- a/shaders/SourceGuidedColor.md
+++ b/shaders/SourceGuidedColor.md
@@ -1,0 +1,175 @@
+# Optional source-guided colour refinement (SDR D3D11)
+
+`SourceGuidedColor.fx` is an opt-in companion effect, not a change to the Feeder
+transport or to the closed neural-rendering model. It refines the colour and
+lightness base of the **whole frame** using colour affinities from the image
+before Feeder, while retaining a controllable neural residual. It does not mask
+out the HUD, paste original text, or recognise a fixed blue/white palette.
+
+## Scope and setup
+
+Requires a working Feeder/consumer installation. This effect does not install,
+enable, repair or distribute any consumer, driver or NGX runtime.
+
+Supported opt-in profile: ReShade 6.8, **D3D11, SDR sRGB, 8-bit backbuffer**.
+The compile guard emits no techniques, textures or samplers by default, or for
+other colour spaces/bit depths/renderers. An absent technique on HDR or another
+renderer is intentional: do not force the defines to bypass the guard.
+
+1. Back up the current preset, then add `SourceGuidedColor.fx` to the existing
+   shader search path. Leave the working Feeder setup unchanged.
+2. Set the effect preprocessor definition `SOURCE_GUIDED_COLOR=1`.
+3. Enable both new techniques and put them immediately around Feeder:
+
+   `motion provider(s) -> SourceGuided_Save -> DLSS5_Feed -> SourceGuided_Apply -> later effects`
+
+4. Enable **Enable source-guided colours** in this effect's settings.
+5. Start with colour separation **0.90**, tone **1.00**, detail **1.00**, and
+   comparison view **Processed**. These ordinary values are saved in the preset.
+
+Keep other colour-changing effects outside the Save/Feed/Apply interval: otherwise
+their changes become part of what the refinement compares. Do not replace the
+entire preset or remove an existing motion-vector provider.
+
+After running the Feeder installer again or updating the installation, re-check
+this order explicitly. The installer can move the provider and `DLSS5_Feed`
+after existing effects; restore `SourceGuided_Save -> DLSS5_Feed -> SourceGuided_Apply`
+before using this companion again. The installer is not changed by this effect.
+
+| Control | Meaning |
+|---|---|
+| Enable source-guided colours | Refinement only; does not toggle NR |
+| Colour separation, 0–1 | Master blend of the source-guided correction; 0 bypasses it |
+| Tone and contrast correction, 0–1 | Scales the lightness-base correction within that blend |
+| Neural residual detail, 0–2 | 1 retains the neural residual; larger values can amplify noise/halos |
+| Processed | Refined output |
+| Source before Feeder | Reconstructed source RGB, with post-Feeder alpha |
+| Neural / post Feeder | Post-Feeder input without the new refinement |
+
+The shader declares an F7 temporary-bypass binding. Check for a game-key conflict;
+its synthetic-key activation was not confirmed during the local game test. Use
+the enable checkbox/comparison selector for an unambiguous manual comparison.
+The existing consumer's NR toggle is separate. Runtime bypass retains the shader's
+buffers/passes; return the macro to **0** to compile them out. Disabling both
+techniques stops their execution but is not a promise of immediate memory release.
+
+## Algorithm and boundary
+
+C0 is the frame before the **whole Feeder chain**, and N is the frame after it.
+C0 is not captured inside the consumer immediately before its NR evaluation.
+Scene and already-composited UI are both processed; true semantic layers cannot
+be recovered from this flat pair by this filter.
+
+Both images are converted from encoded sRGB to Oklab. A radius-4 (9×9) joint
+bilateral filter computes their bases using the **same weights derived from C0**:
+spatial sigma 2.6, lightness sigma 0.10, chroma sigma 0.055, clamp-to-edge samples.
+Nearby areas therefore need not share a base merely because N has made their
+colours similar. The weights are continuous, not hard palette classes.
+
+Let Bs and Bn be these bases, s the master strength, t tone strength and d detail:
+
+`F_lab = N_lab + s * (t * (Bs.L - Bn.L), Bs.ab - Bn.ab) + s * (d - 1) * (N_lab - Bn)`
+
+The selected B++ values are s=0.9, t=1, d=1. A 16-step radial chroma compression
+keeps the result inside the SDR gamut after a lightness clamp. It is not CSS
+perceptual gamut mapping. Post-Feeder alpha is preserved.
+
+A float-exact frame stamp in the source buffer rejects a missing or stale Save.
+It fails closed above frame 16777214; restart the effect runtime then. This checks
+only the companion source buffer, **not** whether the closed consumer produced
+a fresh, successful NR frame. Confirm NR separately with its own overlay/counters.
+
+No extra NGX evaluate, temporal history, motion/depth rewriting, installer change,
+consumer patch or C++ hook is introduced.
+
+## Contributor-local CPU checks
+
+The Python/NumPy reference and synthetic suite are retained by the contributor
+but are **not included in this contribution**. This keeps the upstream change
+limited to the shader and this document, without adding a Python maintenance
+requirement or a build/runtime dependency.
+
+The 25 local tests check colour-conversion values, finite/bounded output, exact
+zero-strength bypass, multiple colours/contaminants, edge gradients and retention
+of synthetic luminance/chromatic detail. They do **not** execute the FX or prove
+game quality. Their reported results are not reproducible from this repository
+alone and are not project CI results. The shader uses the fixed radius-4 profile
+and the selected B++ settings documented above.
+
+## Contributor observations — not CI guarantees
+
+The exact FX below was tested with the ReShade 6.8 compiler and a local isolated
+D3D11 harness: 34/34 WARP and 34/34 RTX cases passed, including alpha, bypass,
+source freshness/range and comparison views. CPU parity tolerance was fixed at
+1/255 beforehand; maximum errors were approximately 0.00003649 / 0.00003379.
+Seven default/off/unsupported-profile compile guards emitted zero resources.
+The local GPU harness and private game-derived fixtures are **not bundled** in
+this small patch; these are reported contributor checks, not results reproducible
+from this repository alone. To validate the actual FX, repeat an in-game check.
+
+Bounded offline observation: Heroes of Might and Magic: Olden Era 0.80.49,
+ReShade 6.8, RTX 4080 SUPER, 3440×1440 SDR D3D11, an existing Feeder/NR installation.
+Three launches reached the saved map. Comparison views, preset persistence,
+camera/hero selection and zoom were checked. The second launch showed ACTIVE NR
+with an increasing success count; white resource text was brighter/less blue,
+and gold/red colourfulness improved. No claim is made that every colour error
+is removed or that the result has final subjective user acceptance.
+
+Separate final-output screenshots were captured at different times. Only static
+UI regions were compared numerically, not the animated world as a synchronous
+pair. Internal consumer NR_ON/OFF captures do not include this downstream effect.
+No game screenshots, raw logs or proprietary binaries are included here.
+
+| Measurement | Observed result | Meaning |
+|---|---|---|
+| Full-frame isolated RTX chain | p50 1.903456 ms, p95 2.463578 ms | 5 warm-up + 30 timestamp samples, not game FPS |
+| Actual ReShade Save+Apply timings | 1.082 and 1.719 ms | Two snapshots, not a percentile distribution |
+| Static in-game frame windows | About 59 FPS | Not an on/off speedup or whole-session smoothness claim |
+| Private textures | 151.17 MiB at 3440×1440 | Two RGBA32F full-frame images; host copies are additional |
+
+The earlier 0.5 ms aspiration was not met. Runtime bypass is not zero-cost.
+The shader digest is
+`DBB37E3482E4D74285CFCB13F87554B848A9EE011C97F0A9D9ED8A68CDED5FC3`.
+The PR base is newer than the locally tested Feeder installation: the existing
+after-technique boundary was inspected, but the new upstream binary was not
+built/deployed in that game. These observations do not certify updated-base NR
+compatibility on another installation.
+
+Update check on 2026-09-06: rebased onto development branch `v0.14.0` at
+`26c002d5156d178c2db438327194077c9ad94418` (includes beta.4). All 25 retained local
+CPU tests passed again with Python 3.12.14 / NumPy 1.26.4; the unchanged FX checked out
+in that tree passed fresh ReShade 6.8 HLSL SM5 compilation and all seven compile
+guards. The D3D11 after-technique boundary and installer/release exclusion were
+inspected at that revision. This was not a new GPU execution or game test of the
+updated Feeder binaries; the runtime observations above remain historical.
+
+## Limitations and reviewer checklist
+
+- Broad, desirable NR colour/lighting changes can also be attenuated. Neural
+  high-frequency colour errors can survive as residual detail.
+- Missing/incorrect upstream depth or motion guides are not fixed by this effect.
+  Local sampled guide warnings remained; increasing NR counters alone do not
+  demonstrate correct temporal reconstruction.
+- Long active play, combat, all UI transitions, reload/resize, other resolutions,
+  HDR, D3D12/Vulkan/other APIs and other games remain unverified.
+- No universal semantic separation, ground-truth colour recovery, model upgrade
+  or guaranteed eye-comfort claim. The effect is intentionally off by default.
+- Reviewer: back up a working offline preset; confirm actual NR activity, both
+  ordered techniques, all three views, coloured/neutral UI, animated edges and
+  camera motion. Compare live GPU timings without screenshot saving. Restart to
+  check persistence. Stop on corruption/crash/flicker; disable only this effect
+  and restore the saved preset. Do not overwrite a working install for this test.
+
+## Attribution and contribution boundary
+
+Original AI-assisted shader implementation and documentation, prepared for contribution
+under this repository's MIT licence. No author signature or external endorsement
+is implied. The maintainer's AI declaration is not rewritten by this contribution.
+
+- Oklab coefficients: [Björn Ottosson](https://bottosson.github.io/posts/oklab/),
+  2021 coefficient update; public-domain option, attribution retained in code.
+- sRGB transfer function: [W3C CSS Color 4](https://www.w3.org/TR/css-color-4/#color-conversion-code).
+- Host/FX semantics: [ReShade FX reference](https://github.com/crosire/reshade-shaders/blob/slim/REFERENCE.md)
+  and ReShade 6.8 runtime; no ReShade compiler code is included in this patch.
+- NumPy was used only for contributor-local checks; neither it nor Python tests
+  are included. There are no media assets, models or game-specific fixtures here.


### PR DESCRIPTION
## Summary

Add an **opt-in SDR D3D11 companion shader** for source-guided whole-frame colour
refinement after Feeder. It addresses a case where neural rendering improved
scene detail but reduced UI colour separation, including a blue cast over neutral
resource text. This is not a white-only fix or HUD bypass: scene and UI colours
are both refined using affinities from the pre-Feeder image.

The module computes source-guided local bases in Oklab and preserves a controllable
neural residual. It does not change Feeder transport, NGX calls, consumer binaries,
failure handling, motion/depth guides, installers, existing defaults or the main README.

## Patch

- One self-contained FX, off at compile time by default and guarded to D3D11 /
  SDR sRGB / 8-bit backbuffers.
- Save/Apply techniques placed immediately around `DLSS5_Feed`, controls and three
  comparison views, preserved output alpha and fail-closed source-frame stamps.
- Focused usage/algorithm/limitations document. Only the FX and this document
  are contributed; the Python reference and tests are retained locally.

## Update after maintainer feedback (2026-09-06)

Rebased onto development branch `v0.14.0` at
`26c002d5156d178c2db438327194077c9ad94418` (includes beta.4).
The retained contributor-local 25 CPU tests pass again on Python 3.12.14 / NumPy 1.26.4, and the
unchanged FX in the rebased checkout passed fresh ReShade 6.8 HLSL SM5 compilation
and all seven compile-off/unsupported-profile guards. The D3D11 after-technique
boundary and explicit installer/release file lists were inspected at that revision.
These are new source/CPU/compiler checks, not new GPU or game tests of beta.4.

Following the maintainer's offered two-file option, exclude the Python reference
and synthetic tests from this contribution and retain them locally. No Python
maintenance requirement or dependency is added to the project. Reported CPU
results cannot be reproduced from this repository alone and are not project CI.
The documentation also warns to re-check Save -> Feed -> Apply after running
the installer, which can reorder techniques. No installer changes are proposed.

## Historical runtime validation and limits

The exact FX was compiled and executed in a local ReShade 6.8/D3D11 harness:
34/34 WARP and 34/34 RTX cases passed; seven unsupported/off profile guards had
zero resources. The GPU harness and private fixture set are not included in this
patch: its runtime checks are contributor-reported, distinct from the local
CPU checks and the new compiler-only checks above.

Bounded offline testing in Olden Era on an RTX 4080 SUPER at 3440x1440 SDR reached
the saved map on three launches, with comparison views and preset persistence
checked. White text, gold and red improved; the neural-rendered scene detail
remained visible. Final user eye-comfort acceptance is still pending.

Cost is material: two RGBA32F buffers (151.17 MiB at this resolution), isolated
chain p50/p95 1.90/2.46 ms; actual ReShade pass snapshots were 1.08/1.72 ms.
These are not game-FPS gains. Good broad neural colour grades can be reduced,
and high-frequency colour errors can survive. No HDR, other-API/game, long-play,
combat or resize/reload guarantee. The current PR base is newer than the tested
Feeder install; I have not upgraded the player's working installation to test it.

This is AI-assisted code and documentation under human direction. No proprietary
binaries, screenshots, raw logs, personal paths, account data or fabricated
authorship signatures are included. Oklab attribution is retained.

## Agreed scope

Optional companion effect in `shaders/`, outside the automatic installer and
release bundle, without transport or default changes. The maintainer confirmed
this scope in the PR discussion and offered the shader/documentation-only option.
The Python reference and tests are not part of this contribution.
