### PR TITLE
Add Optimize/autoprofile, confidence→mask, OFA/velocity, and perf jsonl (on 0.14)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -5,5 +5,5 @@ call "%~dp0tools\vcvars.bat" x64 || exit /b 1
 if not exist build mkdir build
 rc /nologo /fo build\version.res src\version.rc
 rem MinHook (external\minhook, BSD-2) backs the vkCreateDevice hook in src\feed_vk_hook.h.
-cl /nologo /LD /EHsc /O2 /MD /W3 /std:c++20 /Iexternal\reshade\include /Iexternal\ngx /Iexternal\vulkan /Iexternal\imgui /Iexternal\minhook\include /Fobuild\ /Fdbuild\ src\dlss5-feed.cpp external\minhook\src\buffer.c external\minhook\src\hook.c external\minhook\src\trampoline.c external\minhook\src\hde\hde64.c /link /OUT:build\dlss5-feed.addon64 build\version.res external\ngx\libs\nvsdk_ngx_d.lib version.lib kernel32.lib user32.lib advapi32.lib ole32.lib
+cl /nologo /LD /EHsc /O2 /MD /W3 /std:c++20 /Iexternal\reshade\include /Iexternal\ngx /Iexternal\vulkan /Iexternal\imgui /Iexternal\minhook\include /Fobuild\ /Fdbuild\ src\dlss5-feed.cpp external\minhook\src\buffer.c external\minhook\src\hook.c external\minhook\src\trampoline.c external\minhook\src\hde\hde64.c /link /OUT:build\dlss5-feed.addon64 build\version.res external\ngx\libs\nvsdk_ngx_d.lib version.lib kernel32.lib user32.lib advapi32.lib ole32.lib d3dcompiler.lib
 endlocal

--- a/shaders/DLSS5_Feed.fx
+++ b/shaders/DLSS5_Feed.fx
@@ -53,21 +53,40 @@
     A vector failing any test is zeroed (the surface is treated as static -- the right answer
     for a lit wall) and the pixel is flagged in DLSS5_Mask so DLSS trusts the current frame there.
 
+    PROVIDER CONFIDENCE MASK -- LumeniteFX Kernel / QuantMotion also publish a per-pixel
+    confidence map (tConfidence). Optical flow is least trustworthy on moving-object silhouettes,
+    which is where object ghosting comes from: a slightly wrong vector still warps history.
+    When confidence falls below a floor, DLSS5_Mask is raised so DLSS favours the current frame.
+    The contribution is motion-weighted: strong on moving pixels, mild on static low-confidence
+    noise, so textured walls are not over-masked. Providers without a confidence map are a no-op.
+
+    APPEARANCE RESIDUAL MASK -- optical flow can be confidently wrong. After applying the
+    candidate vector, reproject and score illumination-normalised structure (same PatchError as
+    the static hypothesis). A large residual raises DLSS5_Mask even when provider confidence is
+    high. Optional zero-MV on hard fail. All toggles live in the ReShade overlay.
+
+    LIGHTING / CHROMA RESIDUAL -- PatchError removes mean luma, so a calm lighting change on
+    fabric does not trip appearance. A separate mean-luma + chroma test catches "translucent
+    light layers" and hue shifts after reprojection.
+
+    DETAIL (HF) RESIDUAL -- mid-frequency texture smear inside sharp silhouettes: compare
+    high-pass luma (luma - 3x3 blur) current vs reprojected previous. Sub-pixel MV error that
+    still locks edges fails the HF phase match.
+
     The add-on runs DLSS + DLSS 5 neural rendering right after the "DLSS5_Feed" technique has
     rendered, so anything placed below it in the list is applied on top of the neural output.
+
+    TRAA COMPANION (optional) -- LumeniteFX "LUMENITE: TRAA" (lumenite_TRAA.fx):
+      Temporal reprojection AA on top of Feed helps flicker when DLSS history is short
+      (reset_every / OFA churn): it re-accumulates frames after the neural pass.
+      UI/text break because TRAA reprojects the same colour buffer as the HUD -- no real MV,
+      high-contrast glyphs, often drawn without depth. Keep TRAA BELOW DLSS5_Feed.
+      Prefer Edge Detection = Geometric (ignores flat UI in the DLAA prepass). DLSS5oneclick
+      patches TRAA to favour the current frame where DLSS5_Mask distrusts motion / HUD-like
+      luma edges without geometric depth. Optional: UIMask_Top above TRAA, UIMask_Bottom below.
 */
 
 #include "ReShade.fxh"
-
-// D3D9 is not a target. The add-on attaches to D3D10/11/12, OpenGL and Vulkan runtimes only,
-// so if ReShade is on its DirectX 9 backend the effect could never be fed anyway -- and the
-// geometric-fit solver below cannot compile there (SM3 has no tex2Dfetch and must unroll the
-// [loop]s over dynamically indexed arrays, which is the "error X3531: can't unroll loops
-// marked with loop attribute" of issue #56). Say which of those two facts the user is looking
-// at, because the compiler error alone sends people hunting through their shader list.
-#if __RENDERER__ < 0xA000
-    #error "DLSS5_Feed needs D3D10 or newer, and ReShade has loaded its DirectX 9 backend. For a D3D9 game the dgVoodoo2 wrapper must be in effect first (check DisableAndPassThru=false in dgVoodoo.conf); see the README's 'Install for a DirectX 9 game' section. A 64-bit D3D9 game does not need this add-on at all -- renodx-dlss handles those on its own."
-#endif
 
 // Expose ReShade's completed frame to the add-on as an SRV. The 64-bit D3D11 path
 // uses this only when its work-resolution control is below 100%; no extra pass or
@@ -224,8 +243,7 @@ uniform float GEOM_MASK_REJECTED <
     ui_label = "Mask strength on rejected flow";
     ui_tooltip = "Where the provider disagreed with the model but did not win the structure test (fire, smoke,\n"
                  "flicker), the geometric vector is used; this is how strongly DLSS is additionally asked to\n"
-                 "favour the current frame there. 0 = pure history (smoothest), 1 = mostly current frame.\n\n"
-                 "Also used by the static test's first frame when hysteresis holds its vector back.";
+                 "favour the current frame there. 0 = pure history (smoothest), 1 = mostly current frame.";
 > = 0.35;
 
 uniform bool MV_VALIDATE <
@@ -244,18 +262,6 @@ uniform bool VALIDATE_STATIC <
                  "flickering light does not count as motion. When 'did not move' wins, the vector is zeroed\n"
                  "and the pixel is NOT masked -- a static wall wants its full history, which is what smooths\n"
                  "the flicker. This is the test for the flickering-wall case.";
-> = true;
-
-uniform bool STATIC_HYSTERESIS <
-    ui_category = "Validation (flicker / flames / disocclusion)";
-    ui_label = "Static test: require two frames in a row";
-    ui_tooltip = "The static test has no memory: on a low-contrast surface under a slow pan it can win on\n"
-                 "one frame and lose on the next, so the vector alternates between the provider's and zero\n"
-                 "and DLSS alternately reprojects and does not -- a flicker/judder that comes and goes.\n"
-                 "With this on, the vector is only zeroed where the test won on this frame AND the last;\n"
-                 "on the first frame the provider's vector is kept and the pixel is masked instead, so\n"
-                 "DLSS leans on the current frame rather than reprojecting from nowhere.\n"
-                 "Turn it off to compare against the old (per-frame) behaviour.";
 > = true;
 
 uniform float STATIC_BIAS <
@@ -291,7 +297,7 @@ uniform float LUMA_TOLERANCE <
     ui_label = "Luma tolerance";
     ui_tooltip = "How far outside the current 3x3 neighbourhood's luma range the reprojected previous luma\n"
                  "may fall (relative to that range's maximum). Lower = stricter.";
-> = 0.25;
+> = 0.20;
 
 uniform bool VALIDATE_DEPTH <
     ui_category = "Validation (flicker / flames / disocclusion)";
@@ -332,6 +338,173 @@ uniform float MASK_STRENGTH <
                  "1 = fully; 0 = only zero the vector, do not mask.";
 > = 1.0;
 
+#if DLSS5_MV_LOWRES
+// LumeniteFX Kernel / QuantMotion publish tConfidence. Wiring it into DLSS5_Mask cuts object
+// ghosting where optical flow is unsure on silhouettes. See ProviderConfidence() / ConfidenceDistrust().
+uniform bool CONFIDENCE_MASK <
+    ui_category = "Provider confidence mask (object ghosting)";
+    ui_label = "Raise mask from low provider confidence";
+    ui_tooltip = "When the LumeniteFX confidence map falls below the floor, ask DLSS to favour the\n"
+                 "current frame (DLSS5_Mask). Targets moving-object trails from uncertain optical flow.\n"
+                 "Motion-weighted: strong on moving pixels, mild on static low-confidence noise.";
+> = true;
+
+uniform float CONFIDENCE_FLOOR <
+    ui_category = "Provider confidence mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.05; ui_max = 1.0; ui_step = 0.01;
+    ui_label = "Confidence floor";
+    ui_tooltip = "Confidence at or above this contributes nothing. Below it, distrust rises toward 1\n"
+                 "as confidence approaches 0. Raise if the mask eats too much detail; lower if trails remain.";
+> = 0.45;
+
+uniform float CONFIDENCE_MOTION_PX <
+    ui_category = "Provider confidence mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.25; ui_max = 8.0; ui_step = 0.05;
+    ui_label = "Motion weight starts at (px)";
+    ui_tooltip = "Provider flow magnitude (pixels) where the confidence contribution ramps from the\n"
+                 "static weight up to full / boosted strength. Keeps textured static walls from over-masking.";
+> = 1.5;
+
+uniform float CONFIDENCE_STATIC_WEIGHT <
+    ui_category = "Provider confidence mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 1.0; ui_step = 0.05;
+    ui_label = "Weight on near-static pixels";
+    ui_tooltip = "Multiplier on the confidence-driven distrust when flow is below the motion threshold.\n"
+                 "0 = ignore low confidence on static pixels; 1 = treat them like moving silhouettes.";
+> = 0.20;
+
+uniform float CONFIDENCE_MOTION_BOOST <
+    ui_category = "Provider confidence mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.5; ui_max = 2.0; ui_step = 0.05;
+    ui_label = "Weight on moving pixels";
+    ui_tooltip = "Multiplier on the confidence-driven distrust when flow is well above the motion threshold.\n"
+                 "1 = full (floor - conf) / floor; above 1 saturates harder on silhouettes (clamped to 1 after).";
+> = 1.25;
+#endif
+
+// Catches "confidently wrong" optical flow: after reprojecting with the candidate MV, if the
+ // illumination-normalised appearance still disagrees, raise the bias mask (and optionally zero
+ // the vector). Independent of provider confidence -- that is why Shepard-style trails survive
+ // CONFIDENCE_MASK. Does not touch NR intensity.
+uniform bool APPEARANCE_MASK <
+    ui_category = "Appearance residual mask (object ghosting)";
+    ui_label = "Raise mask when reprojected appearance disagrees";
+    ui_tooltip = "Reprojects with the candidate motion vector and scores illumination-normalised structure.\n"
+                 "A large residual means the vector did not explain the pixel -- ask DLSS to favour the\n"
+                 "current frame even if the provider's confidence was high.";
+> = true;
+
+uniform float APPEARANCE_THRESHOLD <
+    ui_category = "Appearance residual mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.005; ui_max = 0.25; ui_step = 0.001;
+    ui_label = "Residual threshold";
+    ui_tooltip = "PatchError above this (after contrast floor) starts raising the mask.\n"
+                 "Lower = more aggressive anti-ghosting; higher = keep more temporal history.";
+> = 0.035;
+
+uniform float APPEARANCE_STRENGTH <
+    ui_category = "Appearance residual mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 2.0; ui_step = 0.05;
+    ui_label = "Mask strength from residual";
+    ui_tooltip = "How hard a failed residual pushes DLSS5_Mask (before the global MASK_STRENGTH).\n"
+                 "1 = residual maps 1:1 into distrust once past the threshold.";
+> = 1.25;
+
+uniform bool APPEARANCE_ZERO_MV <
+    ui_category = "Appearance residual mask (object ghosting)";
+    ui_label = "Also zero the motion vector on residual fail";
+    ui_tooltip = "When the residual fails hard, treat the pixel as having no usable vector (history is\n"
+                 "not warped). Mask still applies. Off by default -- mask-only is usually enough.";
+> = false;
+
+uniform float APPEARANCE_MIN_CONTRAST <
+    ui_category = "Appearance residual mask (object ghosting)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 0.1; ui_step = 0.001;
+    ui_label = "Minimum patch contrast";
+    ui_tooltip = "Below this 3x3 contrast the residual test abstains (no structure to judge).\n"
+                 "Same idea as the static-hypothesis contrast floor.";
+> = 0.010;
+
+// Lighting / chroma: catches illumination and hue changes that mean-removed PatchError ignores.
+uniform bool LIGHTING_MASK <
+    ui_category = "Lighting / chroma residual (detail ghosting)";
+    ui_label = "Raise mask on lighting / chroma mismatch";
+    ui_tooltip = "After reprojection, compare mean luma and chroma (rgb/luma) vs previous frame.\n"
+                 "Targets translucent-looking light layers on moving characters. Does not touch NR.";
+> = true;
+
+uniform float LIGHTING_THRESHOLD <
+    ui_category = "Lighting / chroma residual (detail ghosting)";
+    ui_type = "drag"; ui_min = 0.005; ui_max = 0.35; ui_step = 0.001;
+    ui_label = "Lighting / chroma threshold";
+    ui_tooltip = "Combined mean-luma + chroma residual above this starts raising the mask.\n"
+                 "Lower = more aggressive against lighting ghosting.";
+> = 0.040;
+
+uniform float LIGHTING_STRENGTH <
+    ui_category = "Lighting / chroma residual (detail ghosting)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 2.0; ui_step = 0.05;
+    ui_label = "Lighting / chroma mask strength";
+> = 1.35;
+
+uniform float LIGHTING_CHROMA_WEIGHT <
+    ui_category = "Lighting / chroma residual (detail ghosting)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 2.0; ui_step = 0.05;
+    ui_label = "Chroma vs luma weight";
+    ui_tooltip = "0 = only mean-luma delta; 1 = equal chroma + luma; above 1 emphasises hue shifts.";
+> = 1.0;
+
+// High-frequency detail: texture smear inside silhouettes when edges still look locked.
+uniform bool DETAIL_MASK <
+    ui_category = "Detail residual (texture smear)";
+    ui_label = "Raise mask on high-frequency texture mismatch";
+    ui_tooltip = "Compares high-pass luma (centre minus 3x3 blur) after reprojection.\n"
+                 "Catches shirt/face/floor texel smear when edges stay sharp. Does not touch NR.";
+> = true;
+
+uniform float DETAIL_THRESHOLD <
+    ui_category = "Detail residual (texture smear)";
+    ui_type = "drag"; ui_min = 0.002; ui_max = 0.20; ui_step = 0.001;
+    ui_label = "Detail residual threshold";
+    ui_tooltip = "HF mismatch above this starts raising the mask. Lower = sharper textures, more flicker risk.";
+> = 0.018;
+
+uniform float DETAIL_STRENGTH <
+    ui_category = "Detail residual (texture smear)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 2.0; ui_step = 0.05;
+    ui_label = "Detail mask strength";
+> = 1.40;
+
+uniform float DETAIL_MIN_ENERGY <
+    ui_category = "Detail residual (texture smear)";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 0.08; ui_step = 0.001;
+    ui_label = "Minimum HF energy";
+    ui_tooltip = "Abstain on flat patches (no texture detail to protect).";
+> = 0.004;
+
+// Depth-derived normals: cheap screen-space gradients used only to boost OUR residual /
+// mask confidence on geometric edges. Does NOT invent an NGX normals input.
+uniform bool DEPTH_NORMAL_MASK <
+    ui_category = "Depth normal confidence";
+    ui_label = "Boost mask on depth-normal discontinuities";
+    ui_tooltip = "Estimates view-space normals from linearized depth (ddx/ddy).\n"
+                 "Raises distrust where the normal turns sharply (silhouettes / contact edges)\n"
+                 "so residual masks trust geometry more. No NGX normal buffer is written.";
+> = true;
+
+uniform float DEPTH_NORMAL_STRENGTH <
+    ui_category = "Depth normal confidence";
+    ui_type = "drag"; ui_min = 0.0; ui_max = 1.5; ui_step = 0.05;
+    ui_label = "Depth-normal edge strength";
+> = 0.55;
+
+uniform float DEPTH_NORMAL_THRESHOLD <
+    ui_category = "Depth normal confidence";
+    ui_type = "drag"; ui_min = 0.02; ui_max = 0.6; ui_step = 0.01;
+    ui_label = "Depth-normal edge threshold";
+    ui_tooltip = "1 - |n·n_neighbor| above this starts contributing to the bias mask.";
+> = 0.18;
+
 uniform float2 MV_SIGN <
     ui_type = "drag";
     ui_min = -1.0; ui_max = 1.0; ui_step = 2.0;
@@ -354,10 +527,18 @@ uniform int DEBUG_VIEW <
                "Provider confidence (LumeniteFX only; white = confident)\0"
                "Validation mask (white = vector distrusted, DLSS uses current frame)\0"
                "Validation mask over the image\0"
-               "Validation tests over the image (red = luma, green = depth, blue = consistency, yellow = vector zeroed, orange = static held back)\0"
+               "Validation tests over the image (red = luma, green = depth, blue = consistency, yellow = static wins)\0"
                "Geometry model vectors (colour = direction, brightness = speed)\0"
                "Geometry decision over the image (green = model, red = provider won as moving object, blue = provider rejected)\0"
-               "Geometry fit quality (grey = inlier share; top strip = fit error, black 0 px .. white 8 px)\0";
+               "Geometry fit quality (grey = inlier share; top strip = fit error, black 0 px .. white 8 px)\0"
+               "Confidence → mask contribution (white = distrust raised by low confidence)\0"
+               "Appearance residual (white = high PatchError after reprojection)\0"
+               "Appearance → mask contribution (white = distrust from residual)\0"
+               "Lighting / chroma residual (white = high mismatch)\0"
+               "Lighting / chroma → mask contribution\0"
+               "Detail HF residual (white = texture phase mismatch)\0"
+               "Detail HF → mask contribution\0"
+               "Combined residual → mask (appearance + lighting + detail)\0";
     ui_label = "Debug view (DLSS5_Feed_Debug technique)";
 > = 0;
 
@@ -370,26 +551,17 @@ sampler sDLSS5_Depth { Texture = DLSS5_Depth; MinFilter = POINT; MagFilter = POI
 sampler sDLSS5_Mask  { Texture = DLSS5_Mask;  MinFilter = POINT; MagFilter = POINT; MipFilter = POINT; };
 
 // Previous-frame history for validation (written at the end of the technique)
-texture DLSS5_PrevLuma  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R16F;  };
-texture DLSS5_PrevDepth { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R16F;  };
-texture DLSS5_PrevMV    { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F; };
+texture DLSS5_PrevLuma   { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R16F;   };
+texture DLSS5_PrevDepth  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R16F;   };
+texture DLSS5_PrevMV     { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F;  };
+// Chroma = (R/luma, B/luma); used by lighting/chroma residual (not mean-removed appearance).
+texture DLSS5_PrevChroma { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F;  };
 // Luma may be interpolated (a smooth quantity); depth and vectors must NOT be -- bilinear
 // across an object edge mixes two surfaces' values and fails the test on every edge in motion.
-sampler sDLSS5_PrevLuma  { Texture = DLSS5_PrevLuma;  AddressU = Clamp; AddressV = Clamp; MinFilter = LINEAR; MagFilter = LINEAR; MipFilter = POINT; };
-sampler sDLSS5_PrevDepth { Texture = DLSS5_PrevDepth; AddressU = Clamp; AddressV = Clamp; MinFilter = POINT;  MagFilter = POINT;  MipFilter = POINT; };
-sampler sDLSS5_PrevMV    { Texture = DLSS5_PrevMV;    AddressU = Clamp; AddressV = Clamp; MinFilter = POINT;  MagFilter = POINT;  MipFilter = POINT; };
-
-// The static-hypothesis decision, this frame and last. The test has no memory of its own,
-// so on a low-contrast surface under a slow pan it can win on one frame and lose on the
-// next; the vector then alternates between the provider's and zero, and DLSS alternately
-// reprojects and does not. That is a flicker/judder that no consumer can smooth out, and
-// it comes and goes with the surface (The Surge 2, 2026-09-02). Guides writes StaticNow,
-// History copies it into PrevStatic, and the next frame's Guides reads that -- a texture
-// cannot be sampled and written in the same pass, which is why it takes two of them.
-texture DLSS5_StaticNow  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R8; };
-texture DLSS5_PrevStatic { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R8; };
-sampler sDLSS5_StaticNow  { Texture = DLSS5_StaticNow;  AddressU = Clamp; AddressV = Clamp; MinFilter = POINT; MagFilter = POINT; MipFilter = POINT; };
-sampler sDLSS5_PrevStatic { Texture = DLSS5_PrevStatic; AddressU = Clamp; AddressV = Clamp; MinFilter = POINT; MagFilter = POINT; MipFilter = POINT; };
+sampler sDLSS5_PrevLuma   { Texture = DLSS5_PrevLuma;   AddressU = Clamp; AddressV = Clamp; MinFilter = LINEAR; MagFilter = LINEAR; MipFilter = POINT; };
+sampler sDLSS5_PrevDepth  { Texture = DLSS5_PrevDepth;  AddressU = Clamp; AddressV = Clamp; MinFilter = POINT;  MagFilter = POINT;  MipFilter = POINT; };
+sampler sDLSS5_PrevMV     { Texture = DLSS5_PrevMV;     AddressU = Clamp; AddressV = Clamp; MinFilter = POINT;  MagFilter = POINT;  MipFilter = POINT; };
+sampler sDLSS5_PrevChroma { Texture = DLSS5_PrevChroma; AddressU = Clamp; AddressV = Clamp; MinFilter = LINEAR; MagFilter = LINEAR; MipFilter = POINT; };
 
 // Camera-model fit: a sparse sample grid of (x, y, w, valid | u, v), and the solved model as
 // six 1x1 RGBA32F texels (18 parameters + fit statistics).
@@ -425,6 +597,34 @@ float2 ProviderMV(float2 uv)
 #endif
 }
 
+#if DLSS5_MV_LOWRES
+float ProviderConfidence(float2 uv)
+{
+    return saturate(tex2Dlod(sDLSS5_ProviderConfidence, float4(uv, 0.0, 0.0)).x);
+}
+
+// Distrust in 0..1 from the provider confidence map, motion-weighted using the raw flow
+// magnitude (pixels). Returns 0 when the feature is off or confidence is at/above the floor.
+float ConfidenceDistrust(float2 uv, float2 flow_uv)
+{
+    if (!CONFIDENCE_MASK)
+        return 0.0;
+    const float conf = ProviderConfidence(uv);
+    const float fail = saturate((CONFIDENCE_FLOOR - conf) / max(CONFIDENCE_FLOOR, 1e-5));
+    if (fail <= 0.0)
+        return 0.0;
+    const float mv_px    = length(flow_uv * BUFFER_SCREEN_SIZE);
+    const float motion_w = saturate((mv_px - CONFIDENCE_MOTION_PX) / max(CONFIDENCE_MOTION_PX, 1e-3));
+    const float weight   = lerp(CONFIDENCE_STATIC_WEIGHT, CONFIDENCE_MOTION_BOOST, motion_w);
+    return saturate(fail * weight);
+}
+#else
+float ConfidenceDistrust(float2 uv, float2 flow_uv)
+{
+    return 0.0;
+}
+#endif
+
 float Luma(float2 uv)
 {
     return dot(tex2Dlod(sDLSS5_ColorInput, float4(uv, 0.0, 0.0)).rgb, float3(0.299, 0.587, 0.114));
@@ -457,6 +657,161 @@ float PatchError(float2 uv_cur, float2 uv_prev, out float contrast)
     }
     contrast /= 9.0;
     return err / 9.0;
+}
+
+// Appearance residual after reprojecting with candidate delta-UV mv.
+// Returns float2(raw_error_or_0_if_abstain, distrust_0_to_1).
+float2 AppearanceResidual(float2 uv, float2 mv_uv)
+{
+    if (!APPEARANCE_MASK)
+        return float2(0.0, 0.0);
+    const float2 puv = uv + mv_uv;
+    if (any(puv < 0.0) || any(puv > 1.0))
+        return float2(1.0, saturate(APPEARANCE_STRENGTH)); // off-screen: favour current frame
+    float contrast;
+    const float err = PatchError(uv, puv, contrast);
+    if (contrast < APPEARANCE_MIN_CONTRAST)
+        return float2(0.0, 0.0);
+    const float over = saturate((err - APPEARANCE_THRESHOLD) / max(APPEARANCE_THRESHOLD, 1e-5));
+    return float2(err, saturate(over * APPEARANCE_STRENGTH));
+}
+
+float2 EncodeChroma(float3 rgb)
+{
+    const float l = max(dot(rgb, float3(0.299, 0.587, 0.114)), 1e-3);
+    return rgb.rb / l;
+}
+
+float2 SampleChroma(float2 uv)
+{
+    return EncodeChroma(tex2Dlod(sDLSS5_ColorInput, float4(uv, 0.0, 0.0)).rgb);
+}
+
+// Mean-luma delta + mean-removed chroma structure after reprojection.
+// Returns float2(raw_combined_error, distrust).
+float2 LightingResidual(float2 uv, float2 mv_uv)
+{
+    if (!LIGHTING_MASK)
+        return float2(0.0, 0.0);
+    const float2 puv = uv + mv_uv;
+    if (any(puv < 0.0) || any(puv > 1.0))
+        return float2(1.0, saturate(LIGHTING_STRENGTH));
+
+    const float2 px = BUFFER_PIXEL_SIZE;
+    float mc = 0.0, mp = 0.0;
+    float2 cc[9], pc[9];
+    float2 mcc = 0.0, mpc = 0.0;
+    [unroll] for (int i = 0; i < 9; ++i)
+    {
+        const float2 o = float2(i % 3 - 1, i / 3 - 1) * px;
+        const float lc = Luma(uv + o);
+        const float lp = tex2Dlod(sDLSS5_PrevLuma, float4(puv + o, 0.0, 0.0)).x;
+        mc += lc; mp += lp;
+        cc[i] = SampleChroma(uv + o);
+        pc[i] = tex2Dlod(sDLSS5_PrevChroma, float4(puv + o, 0.0, 0.0)).xy;
+        mcc += cc[i]; mpc += pc[i];
+    }
+    mc /= 9.0; mp /= 9.0;
+    mcc /= 9.0; mpc /= 9.0;
+
+    const float luma_err = abs(mc - mp);
+    float chroma_err = 0.0;
+    [unroll] for (int j = 0; j < 9; ++j)
+        chroma_err += length((cc[j] - mcc) - (pc[j] - mpc));
+    chroma_err /= 9.0;
+
+    const float err = luma_err + LIGHTING_CHROMA_WEIGHT * chroma_err;
+    const float over = saturate((err - LIGHTING_THRESHOLD) / max(LIGHTING_THRESHOLD, 1e-5));
+    return float2(err, saturate(over * LIGHTING_STRENGTH));
+}
+
+float LumaHighPassCur(float2 uv)
+{
+    const float2 px = BUFFER_PIXEL_SIZE;
+    float mean = 0.0;
+    [unroll] for (int i = 0; i < 9; ++i)
+    {
+        const float2 o = float2(i % 3 - 1, i / 3 - 1) * px;
+        mean += Luma(uv + o);
+    }
+    return Luma(uv) - mean / 9.0;
+}
+
+float LumaHighPassPrev(float2 uv)
+{
+    const float2 px = BUFFER_PIXEL_SIZE;
+    float mean = 0.0;
+    [unroll] for (int i = 0; i < 9; ++i)
+    {
+        const float2 o = float2(i % 3 - 1, i / 3 - 1) * px;
+        mean += tex2Dlod(sDLSS5_PrevLuma, float4(uv + o, 0.0, 0.0)).x;
+    }
+    return tex2Dlod(sDLSS5_PrevLuma, float4(uv, 0.0, 0.0)).x - mean / 9.0;
+}
+
+// High-frequency texture phase match after reprojection.
+float2 DetailResidual(float2 uv, float2 mv_uv)
+{
+    if (!DETAIL_MASK)
+        return float2(0.0, 0.0);
+    const float2 puv = uv + mv_uv;
+    if (any(puv < 0.0) || any(puv > 1.0))
+        return float2(1.0, saturate(DETAIL_STRENGTH));
+
+    const float2 px = BUFFER_PIXEL_SIZE;
+    float err = 0.0, energy = 0.0;
+    [unroll] for (int i = 0; i < 9; ++i)
+    {
+        const float2 o = float2(i % 3 - 1, i / 3 - 1) * px;
+        const float hc = LumaHighPassCur(uv + o);
+        const float hp = LumaHighPassPrev(puv + o);
+        err += abs(hc - hp);
+        energy += abs(hc);
+    }
+    err /= 9.0;
+    energy /= 9.0;
+    if (energy < DETAIL_MIN_ENERGY)
+        return float2(0.0, 0.0);
+    const float over = saturate((err - DETAIL_THRESHOLD) / max(DETAIL_THRESHOLD, 1e-5));
+    return float2(err, saturate(over * DETAIL_STRENGTH));
+}
+
+// Combined residual distrust used by the feed pass and debug view 16.
+float CombinedResidualDistrust(float2 uv, float2 mv_uv)
+{
+    const float2 ar = AppearanceResidual(uv, mv_uv);
+    const float2 lr = LightingResidual(uv, mv_uv);
+    const float2 dr = DetailResidual(uv, mv_uv);
+    return max(ar.y, max(lr.y, dr.y));
+}
+
+// Screen-space normal from linearized depth gradients (for residual/mask only).
+float3 DepthNormalSS(float2 uv)
+{
+    const float2 px = BUFFER_PIXEL_SIZE;
+    const float zc = ReShade::GetLinearizedDepth(uv);
+    const float zx = ReShade::GetLinearizedDepth(uv + float2(px.x, 0.0));
+    const float zy = ReShade::GetLinearizedDepth(uv + float2(0.0, px.y));
+    // Approximate view-space positions with unit focal length; only relative orientation matters.
+    const float aspect = (float)BUFFER_WIDTH / max((float)BUFFER_HEIGHT, 1.0);
+    const float3 pc = float3((uv - 0.5) * float2(aspect, 1.0), 1.0) * max(zc, 1e-5);
+    const float3 pxp = float3((uv + float2(px.x, 0.0) - 0.5) * float2(aspect, 1.0), 1.0) * max(zx, 1e-5);
+    const float3 pyp = float3((uv + float2(0.0, px.y) - 0.5) * float2(aspect, 1.0), 1.0) * max(zy, 1e-5);
+    return normalize(cross(pxp - pc, pyp - pc));
+}
+
+// Extra distrust where depth normals disagree with a neighbour (geometric edge).
+float DepthNormalDistrust(float2 uv)
+{
+    if (!DEPTH_NORMAL_MASK)
+        return 0.0;
+    const float2 px = BUFFER_PIXEL_SIZE;
+    const float3 n0 = DepthNormalSS(uv);
+    const float3 nx = DepthNormalSS(uv + float2(px.x, 0.0));
+    const float3 ny = DepthNormalSS(uv + float2(0.0, px.y));
+    const float edge = max(1.0 - saturate(dot(n0, nx)), 1.0 - saturate(dot(n0, ny)));
+    const float over = saturate((edge - DEPTH_NORMAL_THRESHOLD) / max(DEPTH_NORMAL_THRESHOLD, 1e-4));
+    return saturate(over * DEPTH_NORMAL_STRENGTH);
 }
 
 // Per-test failure (0 = fine, 1 = failed, soft in between): x = luma, y = depth, z = consistency,
@@ -557,15 +912,8 @@ bool FitIsUsable()
 }
 
 // Pass 1: sample the provider's flow and the depth on a sparse grid.
-//
-// ReShade cannot skip a whole pass on a uniform, so both fit passes start by checking the
-// one uniform that decides whether anything downstream will ever read them. It matters:
-// PS_FitSolve is a ONE-pixel shader that runs 2 x 920 iterations with two fetches each and
-// a 9x9 Gauss-Jordan solve -- a long serial latency chain on a single lane, every frame,
-// for a result only GeometryDecide consumes. GEOM_ENABLE is off by default.
 void PS_FitSamples(float4 vpos : SV_Position, float2 uv : TEXCOORD, out float4 A : SV_Target0, out float4 B : SV_Target1)
 {
-    if (!GEOM_ENABLE) { A = 0.0; B = 0.0; return; }
     const float2 suv = (floor(vpos.xy) + 0.5) / float2(DLSS5_FIT_W, DLSS5_FIT_H);
     const float  d   = ReShade::GetLinearizedDepth(suv);
     const float2 mv  = ProviderMV(suv);
@@ -581,9 +929,6 @@ void PS_FitSolve(float4 vpos : SV_Position, float2 uv : TEXCOORD,
                  out float4 P0 : SV_Target0, out float4 P1 : SV_Target1, out float4 P2 : SV_Target2,
                  out float4 P3 : SV_Target3, out float4 P4 : SV_Target4, out float4 P5 : SV_Target5)
 {
-    // See PS_FitSamples. P5.z is the sample count FitIsUsable() tests against 40, so a zeroed
-    // P5 also reads as "no usable fit" for anything that looks at it anyway.
-    if (!GEOM_ENABLE) { P0 = 0.0; P1 = 0.0; P2 = 0.0; P3 = 0.0; P4 = 0.0; P5 = 0.0; return; }
     float p[18];
     [unroll] for (int z = 0; z < 18; ++z) p[z] = 0.0;
     float inlier = 0.0, rms = 0.0, used = 0.0;
@@ -719,14 +1064,13 @@ float RawDepth(float2 uv)
 
 void PS_MotionVectors(float4 vpos : SV_Position, float2 uv : TEXCOORD,
                       out float2 mv_out : SV_Target0, out float mask : SV_Target1,
-                      out float depth : SV_Target2, out float static_now : SV_Target3)
+                      out float depth : SV_Target2)
 {
     // Providers hand out "delta UV": previous position = uv + mv. DLSS wants the same
     // direction, in pixels.
     const float2 flow = ProviderMV(uv);
     float2 mv = flow;
     float  distrust = 0.0;
-    static_now = 0.0;   // the geometry path does not run the static test
 
     if (GEOM_ENABLE && FitIsUsable())
     {
@@ -750,45 +1094,55 @@ void PS_MotionVectors(float4 vpos : SV_Position, float2 uv : TEXCOORD,
     else if (MV_VALIDATE)
     {
         const float4 bad = ValidateTests(uv, flow);
-        static_now = bad.w;   // the raw decision, for next frame's hysteresis
-
-        // The static test may only zero the vector once it has won twice in a row. On the
-        // first win the provider's vector is kept and the pixel is masked instead: "prefer
-        // the current frame here" is a safe answer either way, where a zeroed vector on a
-        // pixel that really is moving smears and a full vector on a pixel that really is
-        // static flickers.
-        float static_zero = bad.w;
-        if (STATIC_HYSTERESIS && bad.w > 0.5)
-        {
-            const float won_before = tex2Dlod(sDLSS5_PrevStatic, float4(uv, 0.0, 0.0)).x;
-            if (won_before <= 0.5) { static_zero = 0.0; distrust = max(distrust, GEOM_MASK_REJECTED); }
-        }
-
-        // Hard decision, not a blend: half a vector points at neither where the pixel came
-        // from nor where it is, so DLSS would warp history in from a place that means
-        // nothing. The soft scores stay in the mask, which IS a continuous quantity.
-        const bool zero_vector = max(bad.y, max(bad.z, static_zero)) > 0.5;
-        distrust = max(distrust, max(bad.x, max(bad.y, bad.z)));   // appearance changed / wrong target
-        mv = zero_vector ? float2(0.0, 0.0) : flow;
+        const float  zero_vector = max(bad.y, max(bad.z, bad.w));   // wrong target, or static explains it: treat as static
+        distrust = max(bad.x, max(bad.y, bad.z));                    // appearance changed / wrong target: favour the current frame
+        mv = flow * (1.0 - zero_vector);
     }
 
+    // LumeniteFX confidence → bias mask (object-silhouette ghosting). Uses raw flow for the
+    // motion weight so a validation-zeroed vector still raises the mask on uncertain movers.
+    distrust = max(distrust, ConfidenceDistrust(uv, flow));
+
+    // Appearance residual: OF can be confidently wrong (Shepard face/suit). Score the
+    // reprojected patch; large residual raises the mask independent of provider confidence.
+    {
+        const float2 ar = AppearanceResidual(uv, mv);
+        distrust = max(distrust, ar.y);
+        if (APPEARANCE_ZERO_MV && ar.y > 0.5)
+            mv = 0.0;
+    }
+    // Lighting / chroma: mean-removed appearance ignores calm illumination shifts.
+    {
+        const float2 lr = LightingResidual(uv, mv);
+        distrust = max(distrust, lr.y);
+        if (APPEARANCE_ZERO_MV && lr.y > 0.5)
+            mv = 0.0;
+    }
+    // HF detail: texture smear inside silhouettes when edges still look locked.
+    {
+        const float2 dr = DetailResidual(uv, mv);
+        distrust = max(distrust, dr.y);
+        if (APPEARANCE_ZERO_MV && dr.y > 0.5)
+            mv = 0.0;
+    }
+    // Depth-derived normals → residual/mask confidence only (not an NGX normals input).
+    distrust = max(distrust, DepthNormalDistrust(uv));
+
     mv_out = mv * float2(BUFFER_WIDTH, BUFFER_HEIGHT) * MV_SIGN * MV_SCALE;
-    mask   = saturate(distrust) * MASK_STRENGTH;
+    mask   = distrust * MASK_STRENGTH;
     depth  = RawDepth(uv);
 }
 
 // End of the technique: this frame becomes next frame's history. The raw provider vector is
 // stored (not the validated one), so one distrusted frame does not poison the next test.
-// prev_static carries this frame's static decision over to the next (the Guides pass cannot
-// both sample and write one texture, so it lands here).
 void PS_StoreHistory(float4 vpos : SV_Position, float2 uv : TEXCOORD,
-                     out float luma : SV_Target0, out float depth : SV_Target1, out float2 mv : SV_Target2,
-                     out float prev_static : SV_Target3)
+                     out float luma : SV_Target0, out float depth : SV_Target1,
+                     out float2 mv : SV_Target2, out float2 chroma : SV_Target3)
 {
-    luma  = Luma(uv);
-    depth = ReShade::GetLinearizedDepth(uv);
-    mv    = ProviderMV(uv);
-    prev_static = tex2Dfetch(sDLSS5_StaticNow, int2(vpos.xy)).x;
+    luma   = Luma(uv);
+    depth  = ReShade::GetLinearizedDepth(uv);
+    mv     = ProviderMV(uv);
+    chroma = SampleChroma(uv);
 }
 
 float3 PS_Debug(float4 vpos : SV_Position, float2 uv : TEXCOORD) : SV_Target
@@ -823,18 +1177,9 @@ float3 PS_Debug(float4 vpos : SV_Position, float2 uv : TEXCOORD) : SV_Target
     if (DEBUG_VIEW == 5)
     {
         // Recomputed here against the same history the feed pass used this frame.
-        const float2 flow = ProviderMV(uv);
-        const float4 bad  = ValidateTests(uv, flow);
-        const float3 img  = tex2Dlod(sDLSS5_ColorInput, float4(uv, 0.0, 0.0)).rgb * 0.5;
-        // Yellow is what the feed pass ACTUALLY did, not what the static test proposed: with
-        // hysteresis on, a test that won only this frame keeps its vector. Watch a slow pan
-        // over a flat surface -- yellow that blinks on and off frame by frame is the flicker.
-        const bool  moved  = length(flow * BUFFER_SCREEN_SIZE) > 0.5;
-        const bool  zeroed = moved && length(tex2Dlod(sDLSS5_MV, float4(uv, 0.0, 0.0)).xy) < 1e-4;
-        // Dim orange: the static test won this frame but hysteresis kept the vector (masked instead).
-        const bool  held   = moved && !zeroed && tex2Dlod(sDLSS5_StaticNow, float4(uv, 0.0, 0.0)).x > 0.5;
-        return saturate(img + bad.xyz * 0.9 + (zeroed ? float3(0.6, 0.6, 0.0) : float3(0.0, 0.0, 0.0))
-                                            + (held   ? float3(0.35, 0.18, 0.0) : float3(0.0, 0.0, 0.0)));
+        const float4 bad = ValidateTests(uv, ProviderMV(uv));
+        const float3 img = tex2Dlod(sDLSS5_ColorInput, float4(uv, 0.0, 0.0)).rgb * 0.5;
+        return saturate(img + bad.xyz * 0.9 + bad.w * float3(0.6, 0.6, 0.0));
     }
     if (DEBUG_VIEW == 6)
     {
@@ -857,6 +1202,37 @@ float3 PS_Debug(float4 vpos : SV_Position, float2 uv : TEXCOORD) : SV_Target
         if (uv.y < 0.05) return saturate(s.y / 8.0).xxx;   // fit error strip
         return s.x.xxx;                                    // inlier share
     }
+    if (DEBUG_VIEW == 9)
+    {
+        // Same contribution PS_MotionVectors folds into distrust (before MASK_STRENGTH).
+        return ConfidenceDistrust(uv, ProviderMV(uv)).xxx;
+    }
+    if (DEBUG_VIEW == 10)
+    {
+        const float2 ar = AppearanceResidual(uv, ProviderMV(uv));
+        // Scale raw PatchError for visibility; abstain (0) stays black.
+        return saturate(ar.x / max(APPEARANCE_THRESHOLD * 4.0, 1e-4)).xxx;
+    }
+    if (DEBUG_VIEW == 11)
+    {
+        return AppearanceResidual(uv, ProviderMV(uv)).y.xxx;
+    }
+    if (DEBUG_VIEW == 12)
+    {
+        const float2 lr = LightingResidual(uv, ProviderMV(uv));
+        return saturate(lr.x / max(LIGHTING_THRESHOLD * 4.0, 1e-4)).xxx;
+    }
+    if (DEBUG_VIEW == 13)
+        return LightingResidual(uv, ProviderMV(uv)).y.xxx;
+    if (DEBUG_VIEW == 14)
+    {
+        const float2 dr = DetailResidual(uv, ProviderMV(uv));
+        return saturate(dr.x / max(DETAIL_THRESHOLD * 4.0, 1e-4)).xxx;
+    }
+    if (DEBUG_VIEW == 15)
+        return DetailResidual(uv, ProviderMV(uv)).y.xxx;
+    if (DEBUG_VIEW == 16)
+        return CombinedResidualDistrust(uv, ProviderMV(uv)).xxx;
     float2 mv = tex2Dlod(sDLSS5_MV, float4(uv, 0.0, 0.0)).xy; // pixels
     float angle = atan2(mv.y, mv.x);
     float speed = length(mv);
@@ -873,13 +1249,16 @@ technique DLSS5_Feed
                  "Provider: " DLSS5_MV_PROVIDER_NAME "\n"
                  "Change it with the DLSS5_MV_PROVIDER preprocessor definition (0 texMotionVectors,\n"
                  "1 Launchpad, 2 VORT, 3 LumeniteFX Kernel, 4 LumeniteFX QuantMotion) and enable\n"
-                 "that provider's technique ABOVE this one.";
+                 "that provider's technique ABOVE this one.\n\n"
+                 "Optional LUMENITE: TRAA -- place BELOW this effect (stabilises after neural).\n"
+                 "If UI/text smear: Edge Detection = Geometric; keep Protect UI / text on;\n"
+                 "or wrap TRAA with UIMask_Top / UIMask_Bottom. Do not put TRAA above Feed.";
 >
 {
     pass FitSamples    { VertexShader = PostProcessVS; PixelShader = PS_FitSamples;    RenderTarget0 = DLSS5_FitA; RenderTarget1 = DLSS5_FitB; }
     pass FitSolve      { VertexShader = PostProcessVS; PixelShader = PS_FitSolve;      RenderTarget0 = DLSS5_Cam0; RenderTarget1 = DLSS5_Cam1; RenderTarget2 = DLSS5_Cam2; RenderTarget3 = DLSS5_Cam3; RenderTarget4 = DLSS5_Cam4; RenderTarget5 = DLSS5_Cam5; }
-    pass Guides        { VertexShader = PostProcessVS; PixelShader = PS_MotionVectors; RenderTarget0 = DLSS5_MV; RenderTarget1 = DLSS5_Mask; RenderTarget2 = DLSS5_Depth; RenderTarget3 = DLSS5_StaticNow; }
-    pass History       { VertexShader = PostProcessVS; PixelShader = PS_StoreHistory;  RenderTarget0 = DLSS5_PrevLuma; RenderTarget1 = DLSS5_PrevDepth; RenderTarget2 = DLSS5_PrevMV; RenderTarget3 = DLSS5_PrevStatic; }
+    pass Guides        { VertexShader = PostProcessVS; PixelShader = PS_MotionVectors; RenderTarget0 = DLSS5_MV; RenderTarget1 = DLSS5_Mask; RenderTarget2 = DLSS5_Depth; }
+    pass History       { VertexShader = PostProcessVS; PixelShader = PS_StoreHistory;  RenderTarget0 = DLSS5_PrevLuma; RenderTarget1 = DLSS5_PrevDepth; RenderTarget2 = DLSS5_PrevMV; RenderTarget3 = DLSS5_PrevChroma; }
     DLSS5_MV_REQUEST_PASS   // Launchpad only: ask it to compute optical flow again next frame
 }
 

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -137,6 +137,11 @@ static void Warn(const char *fmt, ...)
 // the first shared-texture build, it can never say anything else. A reporter (and the
 // maintainer answering them) read that as evidence the crash happened during our startup,
 // which it is not: the useful half of the line is the faulting module (issue #44).
+#include "feed_ofa.h"
+#include "feed_velocity.h"
+#include "feed_adapt.h"
+#include "feed_lightstab.h"
+
 static const char *volatile g_where = "nothing yet -- no feed work has run in this process";
 static void Breadcrumb(const char *what) { g_where = what; }
 
@@ -869,7 +874,8 @@ struct Cfg
     int   hdr;             // -1 auto (FP16/R11G11B10 backbuffer = HDR), 0 force SDR, 1 force HDR
     int   depth_inverted;  // -1 auto (RESHADE_DEPTH_INPUT_IS_REVERSED), 0 no, 1 yes
     int   flags;           // -1 auto, else raw DLSS.Feature.Create.Flags
-    int   reset_every;     // 1 = NGX Reset flag every frame (diagnostic: no temporal history)
+    int   reset_every;     // 1 = force every-frame reset (legacy/diagnostic alias of reset_mode=1)
+    int   reset_mode;      // 0 off, 1 every, 2 adaptive (default)
     int   warmup_rebuild;  // frames after the first successful evaluate at which the feature is re-created once (0 = never)
     int   rebuild;         // any change of this number re-creates the feature once (manual trigger)
     int   log_frames;      // how many first frames get a full parameter dump in the log
@@ -923,10 +929,16 @@ struct Cfg
     int   vk_trace;        // per-frame identities + six-stage readbacks (diagnostic only)
 };
 
-static Cfg g_cfg = { 1, 2, -1, -1, -1, 0, 180, 0, 3, 60, 0, 100, 0, 0.3f, 2000, 1, 0, 0, 0, 0, 1.0f, 1.0f, 50, 1, 0, 1, 0 };
+static Cfg g_cfg = { 1, 2, -1, -1, -1, 0, 2, 180, 0, 3, 60, 0, 100, 0, 0.3f, 2000, 1, 0, 0, 0, 0, 1.0f, 1.0f, 50, 1, 0, 1, 0 };
 static int       g_work_resolution_ui = 100;
 static int       g_pending_work_resolution = 0;
 static ULONGLONG g_work_resolution_apply_after = 0;
+
+#include "feed_quality.h"
+static void CfgSave(); // feed_autoprofile.h calls this from Tick / re-run
+#include "feed_autoprofile.h"
+#include "feed_diag.h"
+#include "feed_perf.h"
 
 static void CfgPath(char *out)
 {
@@ -949,6 +961,7 @@ static void CfgWriteDefault()
             "depth_inverted=%d\n"
             "flags=%d\n"
             "reset_every=%d\n"
+            "reset_mode=%d\n"
             "warmup_rebuild=%d\n"
             "rebuild=%d\n"
             "log_frames=%d\n"
@@ -963,12 +976,41 @@ static void CfgWriteDefault()
             "sync_home=%d\n"
             "mv_scale_x=%.3f\n"
             "mv_scale_y=%.3f\n"
-            "stall_log_ms=%d\n",
+            "stall_log_ms=%d\n"
+            "ofa_enabled=%d\n"
+            "ofa_grid=%d\n"
+            "ofa_perf=%d\n"
+            "engine_velocity=%d\n"
+            "velocity_cand=%d\n"
+            "velocity_decode=%d\n"
+            "velocity_scale=%.3f\n"
+            "log_detail=%d\n"
+            "log_detail_every=%d\n"
+            "light_stab=%d\n"
+            "light_stab_strength=%.3f\n"
+            "light_stab_max_delta=%.3f\n"
+            "adapt_mask_thr=%.3f\n"
+            "adapt_mask_thr_vel=%.3f\n"
+            "adapt_luma_thr=%.3f\n"
+            "evaluate_stride=%d\n"
+            "quality_preset=%s\n"
+            "auto_profile_applied=%d\n"
+            "auto_profile=%s\n",
             g_cfg.enabled, g_cfg.mode, g_cfg.hdr, g_cfg.depth_inverted, g_cfg.flags, g_cfg.reset_every,
+            g_cfg.reset_mode,
             g_cfg.warmup_rebuild, g_cfg.rebuild, g_cfg.log_frames, g_cfg.create_delay, g_cfg.preset,
             g_cfg.work_resolution, g_cfg.work_upscale, g_cfg.work_sharpness,
             g_cfg.gpu_timeout_ms, g_cfg.buffer_home, g_cfg.async_home,
-            g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms);
+            g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms,
+            g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
+            g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
+            g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
+            g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
+            g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
+            g_feed_auto.evaluate_stride > 0 ? g_feed_auto.evaluate_stride : 1,
+            FeedQualityCfgName(g_feed_quality),
+            g_feed_auto.applied,
+            g_feed_auto.name[0] ? g_feed_auto.name : "");
     fclose(f);
     Log("[feed] wrote default config to %s", path);
 }
@@ -987,7 +1029,31 @@ static bool CfgReload()
     {
         char  key[64];
         float val = 0.0f;
-        if (sscanf_s(line, "%63[^=]=%f", key, static_cast<unsigned>(sizeof(key)), &val) != 2) continue;
+        if (sscanf_s(line, "%63[^=]=%f", key, static_cast<unsigned>(sizeof(key)), &val) != 2)
+        {
+            char sname[64] = {};
+            if (sscanf_s(line, "%63[^=]=%63s", key, static_cast<unsigned>(sizeof(key)),
+                         sname, static_cast<unsigned>(sizeof(sname))) == 2)
+            {
+                if (_stricmp(key, "quality_preset") == 0 || _stricmp(key, "quality") == 0)
+                {
+                    if (_stricmp(sname, "auto") == 0) { g_feed_quality = FeedQuality_Auto; g_feed_quality_customized = false; }
+                    else if (_stricmp(sname, "low") == 0) { g_feed_quality = FeedQuality_Low; g_feed_quality_customized = false; }
+                    else if (_stricmp(sname, "medium") == 0) { g_feed_quality = FeedQuality_Medium; g_feed_quality_customized = false; }
+                    else if (_stricmp(sname, "high") == 0) { g_feed_quality = FeedQuality_High; g_feed_quality_customized = false; }
+                    else if (_stricmp(sname, "custom") == 0) { g_feed_quality = FeedQuality_Custom; g_feed_quality_customized = true; }
+                }
+                else if (_stricmp(key, "auto_profile") == 0)
+                {
+                    g_feed_auto.kind = FeedAutoProfileParseName(sname);
+                    if (sname[0] && _stricmp(sname, "0") != 0 && _stricmp(sname, "none") != 0)
+                        _snprintf_s(g_feed_auto.name, sizeof(g_feed_auto.name), _TRUNCATE, "%s", sname);
+                    else
+                        g_feed_auto.name[0] = '\0';
+                }
+            }
+            continue;
+        }
         const int iv = static_cast<int>(val);
         if      (_stricmp(key, "enabled")        == 0) next.enabled        = iv;
         else if (_stricmp(key, "mode")           == 0) next.mode           = iv;
@@ -1016,8 +1082,38 @@ static bool CfgReload()
         else if (_stricmp(key, "stall_log_ms")   == 0) next.stall_log_ms   = iv;
         else if (_stricmp(key, "jitter_sign")    == 0) next.jitter_sign    = iv;
         else if (_stricmp(key, "jitter_phases")  == 0) next.jitter_phases  = iv;
+        else if (_stricmp(key, "reset_mode")     == 0) next.reset_mode     = iv;
+        else if (_stricmp(key, "ofa_enabled")    == 0) g_feed_ofa_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "ofa_grid")       == 0) g_feed_ofa_cfg.grid    = iv;
+        else if (_stricmp(key, "ofa_perf")       == 0) g_feed_ofa_cfg.perf    = iv;
+        else if (_stricmp(key, "engine_velocity")== 0) g_feed_velocity_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "velocity_cand")  == 0) g_feed_velocity_cfg.cand = iv;
+        else if (_stricmp(key, "velocity_decode")== 0)
+            g_feed_velocity_cfg.decode = (iv < 0 || iv > 3) ? FeedVelDecode_Auto : iv;
+        else if (_stricmp(key, "velocity_scale") == 0)
+            g_feed_velocity_cfg.scale = (val < 0.05f) ? 0.05f : (val > 8.f ? 8.f : val);
+        else if (_stricmp(key, "log_detail") == 0) g_feed_diag_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "log_detail_every") == 0) g_feed_diag_cfg.every_n = iv > 0 ? iv : 60;
+        else if (_stricmp(key, "light_stab") == 0) g_feed_lightstab_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "light_stab_strength") == 0)
+            g_feed_lightstab_cfg.strength = (val < 0.f) ? 0.f : (val > 1.f ? 1.f : val);
+        else if (_stricmp(key, "light_stab_max_delta") == 0)
+            g_feed_lightstab_cfg.max_delta = (val < 0.01f) ? 0.01f : (val > 0.25f ? 0.25f : val);
+        else if (_stricmp(key, "adapt_mask_thr") == 0)
+            g_feed_adapt_cfg.mask_thr = (val < 0.02f) ? 0.02f : (val > 0.40f ? 0.40f : val);
+        else if (_stricmp(key, "adapt_mask_thr_vel") == 0)
+            g_feed_adapt_cfg.mask_thr_vel = (val < 0.04f) ? 0.04f : (val > 0.50f ? 0.50f : val);
+        else if (_stricmp(key, "adapt_luma_thr") == 0)
+            g_feed_adapt_cfg.luma_thr = (val < 0.01f) ? 0.01f : (val > 0.20f ? 0.20f : val);
+        else if (_stricmp(key, "evaluate_stride") == 0)
+            g_feed_auto.evaluate_stride = iv > 0 ? iv : 1;
+        else if (_stricmp(key, "auto_profile_applied") == 0) g_feed_auto.applied = iv ? 1 : 0;
     }
     fclose(f);
+    if (g_feed_ofa_cfg.grid != 0 && g_feed_ofa_cfg.grid != 1 && g_feed_ofa_cfg.grid != 2 && g_feed_ofa_cfg.grid != 4)
+        g_feed_ofa_cfg.grid = 2;
+    if (g_feed_ofa_cfg.perf != 5 && g_feed_ofa_cfg.perf != 10 && g_feed_ofa_cfg.perf != 20)
+        g_feed_ofa_cfg.perf = 10;
     if (next.mode < 0 || next.mode > 2) next.mode = g_cfg.mode;
     if (next.work_resolution < 50 || next.work_resolution > 100) next.work_resolution = g_cfg.work_resolution;
     if (next.work_upscale < 0 || next.work_upscale > 2) next.work_upscale = g_cfg.work_upscale;
@@ -1028,6 +1124,9 @@ static bool CfgReload()
     // genuinely dead GPU. Clamp to something a contended machine can still live with.
     if (next.gpu_timeout_ms < 100 || next.gpu_timeout_ms > 60000) next.gpu_timeout_ms = g_cfg.gpu_timeout_ms;
     if (next.stall_log_ms < 0 || next.stall_log_ms > 10000) next.stall_log_ms = g_cfg.stall_log_ms;
+    if (next.reset_mode < 0 || next.reset_mode > 2) next.reset_mode = FeedReset_Adaptive;
+    if (next.reset_every) next.reset_mode = FeedReset_Every;
+    g_feed_adapt_cfg.reset_mode = next.reset_mode;
 
     const bool rebuild = next.hdr != g_cfg.hdr || next.depth_inverted != g_cfg.depth_inverted ||
                          next.flags != g_cfg.flags || next.rebuild != g_cfg.rebuild ||
@@ -1054,10 +1153,14 @@ static bool CfgReload()
 // diagnostics (half_home, passthrough, jitter_sign, jitter_phases) have no widget and no
 // line here -- so anything NOT in this list has to be carried over from the old file.
 static const char *const kCfgSavedKeys[] = {
-    "enabled", "mode", "hdr", "depth_inverted", "flags", "reset_every", "warmup_rebuild",
+    "enabled", "mode", "hdr", "depth_inverted", "flags", "reset_every", "reset_mode", "warmup_rebuild",
     "rebuild", "log_frames", "create_delay", "preset", "work_resolution", "work_upscale",
     "work_sharpness", "gpu_timeout_ms", "buffer_home", "async_home", "sync_home",
     "mv_scale_x", "mv_scale_y", "stall_log_ms",
+    "ofa_enabled", "ofa_grid", "ofa_perf", "engine_velocity", "velocity_cand", "velocity_decode", "velocity_scale",
+    "log_detail", "log_detail_every", "light_stab", "light_stab_strength", "light_stab_max_delta",
+    "adapt_mask_thr", "adapt_mask_thr_vel", "adapt_luma_thr", "evaluate_stride",
+    "quality_preset", "auto_profile_applied", "auto_profile",
 };
 
 static bool CfgKeyIsSaved(const char *key)
@@ -1109,14 +1212,31 @@ static void CfgSave()
     FILE *f = nullptr;
     if (fopen_s(&f, path, "w") != 0 || f == nullptr) return;
     fprintf(f,
-        "enabled=%d\nmode=%d\nhdr=%d\ndepth_inverted=%d\nflags=%d\nreset_every=%d\nwarmup_rebuild=%d\n"
+        "enabled=%d\nmode=%d\nhdr=%d\ndepth_inverted=%d\nflags=%d\nreset_every=%d\nreset_mode=%d\nwarmup_rebuild=%d\n"
             "rebuild=%d\nlog_frames=%d\ncreate_delay=%d\npreset=%d\nwork_resolution=%d\nwork_upscale=%d\nwork_sharpness=%.2f\ngpu_timeout_ms=%d\n"
-            "buffer_home=%d\nasync_home=%d\nsync_home=%d\nmv_scale_x=%.3f\nmv_scale_y=%.3f\nstall_log_ms=%d\n",
+            "buffer_home=%d\nasync_home=%d\nsync_home=%d\nmv_scale_x=%.3f\nmv_scale_y=%.3f\nstall_log_ms=%d\n"
+            "ofa_enabled=%d\nofa_grid=%d\nofa_perf=%d\nengine_velocity=%d\n"
+            "velocity_cand=%d\nvelocity_decode=%d\nvelocity_scale=%.3f\n"
+            "log_detail=%d\nlog_detail_every=%d\n"
+            "light_stab=%d\nlight_stab_strength=%.3f\nlight_stab_max_delta=%.3f\n"
+            "adapt_mask_thr=%.3f\nadapt_mask_thr_vel=%.3f\nadapt_luma_thr=%.3f\n"
+            "evaluate_stride=%d\nquality_preset=%s\nauto_profile_applied=%d\nauto_profile=%s\n",
             g_cfg.enabled, g_cfg.mode, g_cfg.hdr, g_cfg.depth_inverted, g_cfg.flags, g_cfg.reset_every,
+            g_cfg.reset_mode,
             g_cfg.warmup_rebuild, g_cfg.rebuild, g_cfg.log_frames, g_cfg.create_delay, g_cfg.preset,
             g_cfg.work_resolution, g_cfg.work_upscale, g_cfg.work_sharpness,
             g_cfg.gpu_timeout_ms, g_cfg.buffer_home, g_cfg.async_home,
-            g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms);
+            g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms,
+            g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
+            g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
+            g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
+            g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
+            g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
+            g_feed_auto.evaluate_stride > 0 ? g_feed_auto.evaluate_stride : 1,
+            g_feed_quality_customized ? "custom" : FeedQualityCfgName(g_feed_quality),
+            g_feed_auto.applied,
+            g_feed_auto.name[0] ? g_feed_auto.name : "");
+    FeedPerfMarkDirty();
     if (!carried.empty()) fputs(carried.c_str(), f);
     fclose(f);
 }
@@ -3983,6 +4103,11 @@ fail:
 
 static void ShutdownSession()
 {
+    FeedOfaShutdown();
+    FeedAdaptRelease();
+    FeedLightStabRelease();
+    FeedVelocityReleaseOut();
+    FeedVelocityReleaseBlit();
     ReleaseFrameResources();
     if (g.params != nullptr) { if (!g_ngx_dying) NVSDK_NGX_D3D12_DestroyParameters(g.params); g.params = nullptr; }
     if (g.ngx_inited && g.dev12 != nullptr) { if (!g_ngx_dying) NVSDK_NGX_D3D12_Shutdown1(g.dev12); g.ngx_inited = false; }
@@ -5144,6 +5269,12 @@ static void TimingTick(LONGLONG entry, LONGLONG exit)
     g.prev_entry = entry;
     g_last_eval_ticks = 0;
 
+    if (interval > 0 && g.qpf > 0)
+    {
+        const double iv_ms = 1000.0 * double(interval) / double(g.qpf);
+        FeedPerfTick(iv_ms);
+    }
+
     if (interval > g.win_max_interval) g.win_max_interval = interval;
     if (total    > g.win_max_total)    g.win_max_total    = total;
     if (eval     > g.win_max_eval)     g.win_max_eval     = eval;
@@ -5297,6 +5428,9 @@ static void FeedFrame12(reshade::api::effect_runtime *rt, reshade::api::command_
     }
     bool ok = g.session_ready || InitSession12(rt);
 
+    // Optimize / auto-profile on DX12: no OFA (D3D11-only). Cost pass prefers evaluate_stride.
+    FeedAutoProfileTick(g.frames_done, /*ofa_capable_d3d11=*/false);
+
     // Same hook-arming grace as the D3D11 path: never call into NGX while the DLSS 5
     // add-on may still be patching its vtable (that has crashed the process at EXEC 0x0),
     // and it re-patches after every runtime recreation.
@@ -5368,6 +5502,11 @@ static void FeedFrame12(reshade::api::effect_runtime *rt, reshade::api::command_
             }
             ++g.frames_done;
         }
+        else if (!FeedAutoProfileShouldEvaluate(g.frames_done))
+        {
+            // Half-rate duty on DX12: skip NGX evaluate this frame.
+            ++g.frames_done;
+        }
         else
         {
             // Park the backbuffer to receive the output; the copy becomes DLSS's colour input.
@@ -5387,7 +5526,7 @@ static void FeedFrame12(reshade::api::effect_runtime *rt, reshade::api::command_
             if (!BeginCommands()) { FeedFail("command list"); }
             else
             {
-                const int reset = (g.need_reset || g_cfg.reset_every) ? 1 : 0;
+                const int reset = FeedAdaptResolveReset(g.need_reset);
                 g.need_reset = false;
 
                 // ReShade parked the effect textures as shader_resource (both SR states on D3D12).
@@ -6448,6 +6587,63 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
     }
     g.mask_ok = mask != nullptr && kd.Width == cd.Width && kd.Height == cd.Height && kd.Format == DXGI_FORMAT_R8_UNORM;
 
+    // Phase 3: engine velocity RT hunter (cfg: engine_velocity=1). Wins over OFA / Lumenite.
+    FeedVelocityBeginFrame(cd.Width, cd.Height);
+    if (g_feed_velocity_cfg.enabled && (g.frames_done % 120) == 1)
+        FeedVelocityTryBind(rt, cd.Width, cd.Height);
+    float vel_scale_x = g_cfg.mv_scale_x, vel_scale_y = g_cfg.mv_scale_y;
+    if (g_feed_velocity_cfg.enabled)
+    {
+        ID3D11Device *vdev = nullptr;
+        ctx->GetDevice(&vdev);
+        if (vdev != nullptr)
+        {
+            if (ID3D11Texture2D *vel_mv = FeedVelocityAcquireMv(rt, dev_api, vdev, ctx, cd.Width, cd.Height))
+            {
+                SafeRelease(mv);
+                mv = vel_mv;
+                mv->GetDesc(&md);
+                if (g_feed_velocity.scale_override)
+                {
+                    vel_scale_x = g_cfg.mv_scale_x * g_feed_velocity.apply_scale_x;
+                    vel_scale_y = g_cfg.mv_scale_y * g_feed_velocity.apply_scale_y;
+                }
+            }
+            FeedVelocityAfterAcquire();
+            vdev->Release();
+        }
+    }
+
+    {
+        const bool ofa_cap = true; // D3D11 feed path
+        FeedAutoProfileTick(g.frames_done, ofa_cap);
+    }
+
+    if (g_feed_ofa_cfg.enabled && !g_feed_velocity.bound_ok)
+    {
+        ID3D11Device *ofa_dev = nullptr;
+        ctx->GetDevice(&ofa_dev);
+        if (ofa_dev != nullptr)
+        {
+            if (ID3D11Texture2D *ofa_mv = FeedOfaUpdate(ofa_dev, ctx, color, cd.Format, cd.Width, cd.Height))
+            {
+                SafeRelease(mv);
+                mv = ofa_mv;
+                mv->AddRef();
+                mv->GetDesc(&md);
+                static bool ofa_said = false;
+                if (!ofa_said)
+                {
+                    ofa_said = true;
+                    Log("[feed] motion vectors: NVIDIA Optical Flow (ofa_grid=%d ofa_perf=%d) — "
+                        "ReShade/Lumenite MV ignored this frame",
+                        g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf);
+                }
+            }
+            ofa_dev->Release();
+        }
+    }
+
     bool ok = true;
     if (cd.Width != md.Width || cd.Height != md.Height || cd.Width != dd.Width || cd.Height != dd.Height ||
         cd.SampleDesc.Count != 1 || md.Format != DXGI_FORMAT_R16G16_FLOAT || dd.Format != DXGI_FORMAT_R32_FLOAT)
@@ -6529,7 +6725,8 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
         // history so a reset frame is the unshifted one.
         if (g.sr_active)
         {
-            if (g.need_reset || g_cfg.reset_every) g.jitter_index = 0;
+            if (g.need_reset || g_feed_adapt_cfg.reset_mode == FeedReset_Every || g_feed_adapt.want_reset)
+                g.jitter_index = 0;
             HaltonJitter(g.jitter_index, g.jitter_phases, &g.jitter_x, &g.jitter_y);
         }
         Breadcrumb("preparing work-resolution inputs");
@@ -6540,11 +6737,34 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
                                   reinterpret_cast<ID3D11ShaderResourceView *>(mask_srv.handle),
                                   cd.Width, cd.Height);
 
+        if (ok)
+        {
+            if ((g.frames_done & 1ull) == 0ull)
+            {
+                ID3D11Device *adev = nullptr;
+                ctx->GetDevice(&adev);
+                if (adev != nullptr)
+                {
+                    FeedAdaptSample(adev, ctx, g.tex11[SLOT_COLOR],
+                                    g.mask_ok ? g.tex11[SLOT_MASK] : nullptr,
+                                    g.mask_ok, g.width, g.height,
+                                    g_feed_velocity.bound_ok);
+                    adev->Release();
+                }
+            }
+        }
+
         if (ok && g_cfg.mode == 1)
         {
             // Transport test: what went out comes straight back, through the same copy-back path.
             ctx->CopyResource(g.tex11[SLOT_OUTPUT], g.tex11[SLOT_COLOR]);
             BlitOutputToBackbuffer(ctx, rtv11);
+            ++g.frames_done;
+        }
+        else if (ok && !FeedAutoProfileShouldEvaluate(g.frames_done))
+        {
+            if (g.tex11[SLOT_OUTPUT] != nullptr)
+                BlitOutputToBackbuffer(ctx, rtv11);
             ++g.frames_done;
         }
         else if (ok)
@@ -6575,7 +6795,7 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
                 Barrier(nr_out, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
                 FeedEndPhase(g.list);
 
-                const int reset = (g.need_reset || g_cfg.reset_every) ? 1 : 0;
+                const int reset = FeedAdaptResolveReset(g.need_reset);
                 g.need_reset = false;
 
                 NVSDK_NGX_D3D12_DLSS_Eval_Params ep = {};
@@ -6592,8 +6812,8 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
                 ep.InRenderSubrectDimensions.Width  = g.width;
                 ep.InRenderSubrectDimensions.Height = g.height;
                 ep.InReset           = reset;
-                ep.InMVScaleX        = g_cfg.mv_scale_x;
-                ep.InMVScaleY        = g_cfg.mv_scale_y;
+                ep.InMVScaleX        = vel_scale_x;
+                ep.InMVScaleY        = vel_scale_y;
                 ep.InPreExposure     = 1.0f;
                 ep.InExposureScale   = 1.0f;
 
@@ -6646,10 +6866,33 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
                 {
                     Breadcrumb("waiting for the D3D12 result");
                     g.ctx4->Wait(g.fence11, v_out);
+                    {
+                        ID3D11Device *lsdev = nullptr;
+                        ctx->GetDevice(&lsdev);
+                        if (lsdev != nullptr && g.tex11[SLOT_OUTPUT] != nullptr && g.output_srv != nullptr)
+                        {
+                            ID3D11ShaderResourceView *mv_work_srv = nullptr;
+                            if (g.tex11[SLOT_MV] != nullptr)
+                            {
+                                D3D11_SHADER_RESOURCE_VIEW_DESC svd = {};
+                                svd.Format = DXGI_FORMAT_R16G16_FLOAT;
+                                svd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+                                svd.Texture2D.MipLevels = 1;
+                                lsdev->CreateShaderResourceView(g.tex11[SLOT_MV], &svd, &mv_work_srv);
+                            }
+                            const UINT ow = g.output_width != 0 ? g.output_width : g.width;
+                            const UINT oh = g.output_height != 0 ? g.output_height : g.height;
+                            FeedLightStabApply(lsdev, ctx, g.tex11[SLOT_OUTPUT], g.output_srv,
+                                               g.tex11[SLOT_MV], mv_work_srv, ow, oh);
+                            if (mv_work_srv) mv_work_srv->Release();
+                            lsdev->Release();
+                        }
+                    }
                     BlitOutputToBackbuffer(ctx, rtv11);
                     const UINT64 n = ++g.frames_done;
                     g.consecutive_fails = 0;
                     if (g.sr_active) ++g.jitter_index;
+                    FeedDiagOnFrame(n, reset, g.mask_ok, g.backbuffer_width, g.backbuffer_height, g.width, g.height);
                     if (n <= static_cast<UINT64>(g_cfg.log_frames) || (n % 1800) == 0)
                         Log("[feed] frame %llu delivered (%ux%u at %d%% -> %ux%u, reset=%d%s, jitter %+.3f,%+.3f)", n,
                             g.width, g.height, g_cfg.work_resolution,
@@ -7169,6 +7412,71 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
     }
 
     ImGui::Separator();
+    ImGui::TextUnformatted("Quality preset");
+    ImGui::TextDisabled("Recommendation only — does not change NR intensity. FX residual masks are set at Install.");
+    {
+        const bool ofa_cap = rt != nullptr &&
+            rt->get_device()->get_api() == reshade::api::device_api::d3d11;
+        int combo_i = g_feed_quality == FeedQuality_Low ? 1 :
+                      g_feed_quality == FeedQuality_Medium ? 2 :
+                      g_feed_quality == FeedQuality_High ? 3 : 0;
+        const char *items = "Auto\0Low\0Medium\0High\0";
+        if (ImGui::Combo("##quality", &combo_i, items))
+        {
+            FeedQualityApply((FeedQualityChoice)combo_i, ofa_cap);
+            g_feed_auto.applied = 1;
+            dirty = true;
+        }
+        ImGui::SameLine();
+        if (g_feed_quality_customized || g_feed_quality == FeedQuality_Custom)
+            ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.3f, 1.0f), "Quality: Customized");
+        else
+            ImGui::Text("Quality: %s", FeedQualityName(g_feed_quality));
+    }
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Optimize (telemetry, not screenshot CV)");
+    {
+        const bool ofa_cap_ui = rt != nullptr &&
+            rt->get_device()->get_api() == reshade::api::device_api::d3d11;
+        const char *api_s = "unknown";
+        if (rt != nullptr)
+        {
+            switch (rt->get_device()->get_api())
+            {
+            case reshade::api::device_api::d3d11: api_s = "D3D11"; break;
+            case reshade::api::device_api::d3d12: api_s = "D3D12"; break;
+            case reshade::api::device_api::vulkan: api_s = "Vulkan"; break;
+            case reshade::api::device_api::opengl: api_s = "OpenGL"; break;
+            default: break;
+            }
+        }
+        ImGui::TextDisabled("API %s | ofa_cap=%d", api_s, ofa_cap_ui ? 1 : 0);
+    }
+    ImGui::TextWrapped("%s", g_feed_auto.status[0] ? g_feed_auto.status :
+                       (g_feed_auto.applied ? "Optimize: cached" : "Optimize: pending first attach"));
+    ImGui::SameLine(); HelpMarker(
+        "Settles, then picks knobs from numeric signals:\n"
+        "- engine velocity bind/score -> Adaptive reset\n"
+        "- no velocity -> Every reset + LightStab (+ OFA on D3D11)\n"
+        "- high reset_rate / lighting mask -> LightStab / thr\n"
+        "- low FPS -> work%% / OFA FAST / half-rate evaluate (DX12: stride first)\n"
+        "Writes dlss5-feed.cfg (auto_profile_applied=1). Manual edits mark Custom.");
+    if (ImGui::Button("Optimize"))
+    {
+        FeedAutoProfileRequestOptimize();
+        dirty = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Re-run auto profile"))
+    {
+        FeedAutoProfileRequestRerun();
+        dirty = true;
+    }
+    if (g_feed_auto.evaluate_stride > 1)
+        ImGui::TextDisabled("evaluate_stride=%d (half-rate duty)", g_feed_auto.evaluate_stride);
+
+    ImGui::Separator();
     ImGui::TextUnformatted("Status");
     ImGui::Text("Session: %s", g.disabled ? "disabled" : g.session_ready ? "open" : "not started");
     if (g.disabled && g_disable_why[0])
@@ -7244,6 +7552,8 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
         {
             g_pending_work_resolution = g_work_resolution_ui;
             g_work_resolution_apply_after = GetTickCount64() + 400;
+            g_feed_quality_customized = true;
+            g_feed_quality = FeedQuality_Custom;
         }
         ImGui::SameLine(); HelpMarker("Scales both axes of the private DLAA + Neural Rendering work textures. "
                                       "The game/backbuffer stays native-sized. Applied once 400 ms after dragging stops.");
@@ -7282,8 +7592,65 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
     int hdr_idx = g_cfg.hdr + 1, di_idx = g_cfg.depth_inverted + 1;
     if (ImGui::Combo("HDR", &hdr_idx, kTri, 3)) { g_cfg.hdr = hdr_idx - 1; dirty = true; rebuild = true; }
     if (ImGui::Combo("Depth inverted", &di_idx, kTri, 3)) { g_cfg.depth_inverted = di_idx - 1; dirty = true; rebuild = true; }
-    bool reset_every = g_cfg.reset_every != 0;
-    if (ImGui::Checkbox("Reset every frame (diagnostic)", &reset_every)) { g_cfg.reset_every = reset_every ? 1 : 0; dirty = true; }
+    static const char *kResetMode[] = { "Off", "Every frame (diagnostic)", "Adaptive (auto)" };
+    int rmi = g_cfg.reset_mode;
+    if (rmi < 0 || rmi > 2) rmi = FeedReset_Adaptive;
+    if (g_cfg.reset_every) rmi = FeedReset_Every;
+    if (ImGui::Combo("History reset", &rmi, kResetMode, 3))
+    {
+        g_cfg.reset_mode = rmi;
+        g_cfg.reset_every = (rmi == FeedReset_Every) ? 1 : 0;
+        g_feed_adapt_cfg.reset_mode = rmi;
+        FeedAutoProfileMarkCustomized();
+        dirty = true;
+    }
+    ImGui::SameLine(); HelpMarker(
+        "Adaptive (default): resets DLSS history only when the bias mask or scene brightness jumps — "
+        "anti-ghosting without always killing temporal stability (lighting flicker).\n"
+        "Every frame: your diagnostic win (zero ghosting, more light shimmer).\n"
+        "Off: never reset except on resolution/feature rebuild.");
+    ImGui::TextDisabled("%s", g_feed_adapt.status[0] ? g_feed_adapt.status : "Reset: —");
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Adaptive)
+    {
+        if (ImGui::SliderFloat("Adapt mask threshold", &g_feed_adapt_cfg.mask_thr, 0.02f, 0.40f, "%.2f"))
+            dirty = true;
+        if (ImGui::SliderFloat("Adapt luma threshold", &g_feed_adapt_cfg.luma_thr, 0.01f, 0.15f, "%.2f"))
+            dirty = true;
+    }
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Post-DLSS lighting flicker dampener");
+    bool ls = g_feed_lightstab_cfg.enabled != 0;
+    if (ImGui::Checkbox("Damp small static lighting flicker (after DLSS)", &ls))
+    { g_feed_lightstab_cfg.enabled = ls ? 1 : 0; FeedAutoProfileMarkCustomized(); dirty = true; }
+    ImGui::SameLine(); HelpMarker(
+        "Not a shadow-map cache — we only see the final image after DLSS. "
+        "Requires motion vectors: only pixels with |MV| <= mv_eps (near-static) and a small luma wobble "
+        "are damped. Camera pans / missing MV leave the frame untouched (avoids throb). "
+        "Cfg: light_stab / light_stab_strength / light_stab_max_delta.");
+    if (ls)
+    {
+        if (ImGui::SliderFloat("LightStab strength", &g_feed_lightstab_cfg.strength, 0.0f, 1.0f, "%.2f"))
+            dirty = true;
+        if (ImGui::SliderFloat("LightStab max luma delta", &g_feed_lightstab_cfg.max_delta, 0.01f, 0.20f, "%.3f"))
+            dirty = true;
+        ImGui::TextDisabled("%s", g_feed_lightstab.status[0] ? g_feed_lightstab.status : "");
+    }
+
+    bool detail = g_feed_diag_cfg.enabled != 0;
+    if (ImGui::Checkbox("Extended [diag] log (for bug reports)", &detail))
+    { g_feed_diag_cfg.enabled = detail ? 1 : 0; dirty = true; }
+    if (detail)
+    {
+        if (ImGui::SliderInt("Diag every N frames", &g_feed_diag_cfg.every_n, 15, 300))
+            dirty = true;
+        if (ImGui::Button("Dump diag now"))
+        {
+            FeedDiagDump("manual", g_feed_adapt.want_reset ? 1 : 0, g.frames_done,
+                         g.mask_ok, g.backbuffer_width, g.backbuffer_height, g.width, g.height);
+        }
+        ImGui::TextDisabled("Paste lines tagged [diag] from dlss5-feed.log");
+    }
 
     ImGui::Separator();
     ImGui::TextUnformatted("DLSS render preset");
@@ -7303,6 +7670,103 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
     else if (g.handles_ok)
         ImGui::TextColored(ImVec4(0.5f, 0.9f, 0.5f, 1.0f), "provider matches the shader's DLSS5_MV_PROVIDER");
     ImGui::TextWrapped("%s", g_mv_probe);
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("NVIDIA Optical Flow (anti-ghosting MV)");
+    bool ofa_on = g_feed_ofa_cfg.enabled != 0;
+    if (ImGui::Checkbox("Use hardware Optical Flow instead of ReShade/Lumenite MV", &ofa_on))
+    { g_feed_ofa_cfg.enabled = ofa_on ? 1 : 0; g_feed_quality_customized = true; g_feed_quality = FeedQuality_Custom; dirty = true; }
+    ImGui::SameLine(); HelpMarker("Dedicated NVIDIA Optical Flow engine (nvofapi64.dll) on Turing+. "
+                                  "Better object motion than shader optical flow; little CUDA cost. D3D11 path. "
+                                  "Init once, runs every frame. Appearance / lighting / detail residual masks "
+                                  "in DLSS5_Feed.fx still apply on top. Cfg key: ofa_enabled.");
+    if (ofa_on)
+    {
+        if (g_feed_velocity.bound_ok)
+            ImGui::TextColored(ImVec4(0.5f, 0.9f, 0.5f, 1.0f), "MV source: engine velocity (Optical Flow idle)");
+        else if (FeedOfaReady())
+            ImGui::TextColored(ImVec4(0.5f, 0.9f, 0.5f, 1.0f), "MV source: NVIDIA Optical Flow");
+        else
+            ImGui::TextDisabled("MV source: waiting for Optical Flow session (needs a few frames)");
+
+        if (g.launchpad.handle != 0 && rt != nullptr && rt->get_technique_state(g.launchpad))
+            ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.3f, 1.0f),
+                               "Lumenite/provider technique is still enabled — you can turn it off in Home; "
+                               "Optical Flow already replaces those MVs.");
+
+        static const char *kGrid[] = { "Off (0)", "1 px", "2 px (default)", "4 px" };
+        static const int   kGridV[] = { 0, 1, 2, 4 };
+        int gi = 2;
+        for (int i = 0; i < 4; ++i) if (kGridV[i] == g_feed_ofa_cfg.grid) gi = i;
+        if (ImGui::Combo("Optical Flow grid", &gi, kGrid, 4)) { g_feed_ofa_cfg.grid = kGridV[gi]; dirty = true; }
+        static const char *kPerf[] = { "SLOW (5)", "MEDIUM (10)", "FAST (20)" };
+        static const int   kPerfV[] = { 5, 10, 20 };
+        int pi = 1;
+        for (int i = 0; i < 3; ++i) if (kPerfV[i] == g_feed_ofa_cfg.perf) pi = i;
+        if (ImGui::Combo("Optical Flow performance", &pi, kPerf, 3)) { g_feed_ofa_cfg.perf = kPerfV[pi]; dirty = true; }
+        ImGui::TextDisabled(FeedOfaReady() ? "Optical Flow session: ready" : "Optical Flow session: not ready yet");
+    }
+    bool vel_on = g_feed_velocity_cfg.enabled != 0;
+    if (ImGui::Checkbox("Hunt & use engine velocity RT (object MV)", &vel_on))
+    { g_feed_velocity_cfg.enabled = vel_on ? 1 : 0; dirty = true; }
+    ImGui::SameLine(); HelpMarker("Tracks D3D11 float render targets during draws (PPOM-style). "
+                                  "When a full-res RG16F velocity buffer is found, it replaces Optical Flow / Lumenite. "
+                                  "UE3/ME: turn Motion Blur ON in-game so the engine writes velocity. "
+                                  "Priority: engine velocity > Optical Flow > Lumenite.");
+    if (vel_on)
+    {
+        if (g_feed_velocity.bound_ok)
+            ImGui::TextColored(ImVec4(0.5f, 0.9f, 0.5f, 1.0f), "MV source: engine velocity (%s) %s %dx%d",
+                               g_feed_velocity.bound_src,
+                               g_feed_velocity.name[0] ? g_feed_velocity.name : "?",
+                               g_feed_velocity.last_w, g_feed_velocity.last_h);
+        else if (g_feed_ofa_cfg.enabled && FeedOfaReady())
+            ImGui::TextDisabled("MV source: Optical Flow (no velocity RT bound this frame)");
+        else
+            ImGui::TextDisabled("MV source: ReShade/Lumenite (velocity not bound)");
+
+        ImGui::TextWrapped("%s", g_feed_velocity.overlay_line[0] ? g_feed_velocity.overlay_line : "");
+        ImGui::TextDisabled("Candidates: %d (Motion Blur may be required)", g_feed_velocity.cand_count);
+
+        if (g_feed_velocity.cand_count > 0)
+        {
+            static char labels[32][96];
+            static const char *ptrs[33];
+            int n = 0;
+            _snprintf_s(labels[0], sizeof(labels[0]), _TRUNCATE, "Auto (best score)");
+            ptrs[n++] = labels[0];
+            const int max_show = g_feed_velocity.cand_count < 31 ? g_feed_velocity.cand_count : 31;
+            for (int i = 0; i < max_show; ++i)
+            {
+                const FeedVelocityCand &c = g_feed_velocity.cands[i];
+                _snprintf_s(labels[i + 1], sizeof(labels[i + 1]), _TRUNCATE,
+                            "#%d %s %ux%u score=%d%s", i, FeedVelocityFmtLabel(c.fmt),
+                            c.width, c.height, c.score, c.name_hit ? " *" : "");
+                ptrs[i + 1] = labels[i + 1];
+                n++;
+            }
+            int sel = g_feed_velocity_cfg.cand < 0 ? 0 : g_feed_velocity_cfg.cand + 1;
+            if (sel >= n) sel = 0;
+            if (ImGui::Combo("Velocity candidate", &sel, ptrs, n))
+            {
+                g_feed_velocity_cfg.cand = (sel <= 0) ? -1 : sel - 1;
+                dirty = true;
+            }
+        }
+
+        static const char *kDec[] = { "Auto", "Raw pixels (DLSS)", "Delta UV", "UE packed" };
+        int di = g_feed_velocity_cfg.decode;
+        if (di < 0 || di > 3) di = 0;
+        if (ImGui::Combo("Velocity decode", &di, kDec, 4))
+        { g_feed_velocity_cfg.decode = di; dirty = true; }
+        if (ImGui::SliderFloat("Velocity scale", &g_feed_velocity_cfg.scale, 0.1f, 4.0f, "%.2f"))
+            dirty = true;
+        if (ImGui::Button("Rescan velocity RTs"))
+        { FeedVelocityClearCands(); dirty = true; }
+        ImGui::SameLine();
+        ImGui::TextDisabled("Enable Motion Blur in-game if the list stays empty");
+    }
+
     ImGui::TextWrapped("Change the provider with DLSS5_Feed.fx's DLSS5_MV_PROVIDER preprocessor definition: "
                        "0 texMotionVectors (qUINT, dh_uber_motion), 1 Launchpad, 2 VORT, 3 LumeniteFX Kernel, 4 LumeniteFX QuantMotion.");
     if (ImGui::SliderFloat("MV scale X", &g_cfg.mv_scale_x, 0.0f, 4.0f)) dirty = true;
@@ -7339,6 +7803,37 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
 }
 
 // ---------------------------------------------------------------------------
+
+
+static void OnBindRenderTargets(reshade::api::command_list *cmd_list, uint32_t count,
+                                const reshade::api::resource_view *rtvs, reshade::api::resource_view dsv)
+{
+    FeedVelocityOnBindRTs(cmd_list, count, rtvs, dsv);
+}
+
+static bool OnDraw(reshade::api::command_list *cmd_list, uint32_t /*vertices*/, uint32_t /*instances*/,
+                   uint32_t /*first_vertex*/, uint32_t /*first_instance*/)
+{
+    return FeedVelocityOnDraw(cmd_list);
+}
+
+static bool OnDrawIndexed(reshade::api::command_list *cmd_list, uint32_t /*indices*/, uint32_t /*instances*/,
+                          uint32_t /*first_index*/, int32_t /*vertex_offset*/, uint32_t /*first_instance*/)
+{
+    return FeedVelocityOnDraw(cmd_list);
+}
+
+static void OnInitResource(reshade::api::device *device, const reshade::api::resource_desc &desc,
+                           const reshade::api::subresource_data *, reshade::api::resource_usage,
+                           reshade::api::resource resource)
+{
+    FeedVelocityOnInitResource(device, desc, resource);
+}
+
+static void OnDestroyResource(reshade::api::device *, reshade::api::resource resource)
+{
+    FeedVelocityOnDestroyResource(resource);
+}
 
 // Fired by ReShade before the device (for Vulkan: from inside its vkCreateInstance
 // hook, i.e. before the game's vkCreateDevice). That is the one moment the interop
@@ -7433,6 +7928,11 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
         reshade::register_event<reshade::addon_event::reshade_reloaded_effects>(OnReloadedEffects);
         reshade::register_event<reshade::addon_event::reshade_render_technique>(OnRenderTechnique);
         reshade::register_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
+        reshade::register_event<reshade::addon_event::init_resource>(OnInitResource);
+        reshade::register_event<reshade::addon_event::destroy_resource>(OnDestroyResource);
+        reshade::register_event<reshade::addon_event::bind_render_targets_and_depth_stencil>(OnBindRenderTargets);
+        reshade::register_event<reshade::addon_event::draw>(OnDraw);
+        reshade::register_event<reshade::addon_event::draw_indexed>(OnDrawIndexed);
         reshade::register_overlay(nullptr, DrawOverlay);
     }
     else if (reason == DLL_PROCESS_DETACH)
@@ -7458,6 +7958,13 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
         reshade::unregister_event<reshade::addon_event::reshade_reloaded_effects>(OnReloadedEffects);
         reshade::unregister_event<reshade::addon_event::reshade_render_technique>(OnRenderTechnique);
         reshade::unregister_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
+        reshade::unregister_event<reshade::addon_event::init_resource>(OnInitResource);
+        reshade::unregister_event<reshade::addon_event::destroy_resource>(OnDestroyResource);
+        reshade::unregister_event<reshade::addon_event::bind_render_targets_and_depth_stencil>(OnBindRenderTargets);
+        reshade::unregister_event<reshade::addon_event::draw>(OnDraw);
+        reshade::unregister_event<reshade::addon_event::draw_indexed>(OnDrawIndexed);
+        FeedVelocityReleaseOut();
+        FeedVelocityReleaseBlit();
         FeedVkFramePresentRemove();
         FeedVkHookRemove();   // before this code is unmapped -- ReShade reloads add-ons per Vulkan instance
         g_ngx_dying = true;   // process is exiting: never call back into NGX

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -140,6 +140,7 @@ static void Warn(const char *fmt, ...)
 #include "feed_ofa.h"
 #include "feed_velocity.h"
 #include "feed_early_color.h"
+#include "feed_async.h"
 #include "feed_adapt.h"
 #include "feed_lightstab.h"
 
@@ -987,6 +988,10 @@ static void CfgWriteDefault()
             "velocity_scale=%.3f\n"
             "early_color=%d\n"
             "early_color_cand=%d\n"
+            "async_feed=%d\n"
+            "key_async_feed=%d\n"
+            "hud_stats=%d\n"
+            "key_hud=%d\n"
             "log_detail=%d\n"
             "log_detail_every=%d\n"
             "light_stab=%d\n"
@@ -1008,6 +1013,7 @@ static void CfgWriteDefault()
             g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
             g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
             g_feed_early_color_cfg.enabled, g_feed_early_color_cfg.cand,
+            g_feed_async_cfg.enabled, g_feed_async_cfg.key, g_feed_hud_cfg.enabled, g_feed_hud_cfg.key,
             g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
             g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
             g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
@@ -1098,6 +1104,10 @@ static bool CfgReload()
             g_feed_velocity_cfg.scale = (val < 0.05f) ? 0.05f : (val > 8.f ? 8.f : val);
         else if (_stricmp(key, "early_color") == 0) g_feed_early_color_cfg.enabled = iv ? 1 : 0;
         else if (_stricmp(key, "early_color_cand") == 0) g_feed_early_color_cfg.cand = iv;
+        else if (_stricmp(key, "async_feed") == 0) g_feed_async_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "key_async_feed") == 0) g_feed_async_cfg.key = iv > 0 ? iv : 0x79;
+        else if (_stricmp(key, "hud_stats") == 0) g_feed_hud_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "key_hud") == 0) g_feed_hud_cfg.key = iv > 0 ? iv : 0x78;
         else if (_stricmp(key, "log_detail") == 0) g_feed_diag_cfg.enabled = iv ? 1 : 0;
         else if (_stricmp(key, "log_detail_every") == 0) g_feed_diag_cfg.every_n = iv > 0 ? iv : 60;
         else if (_stricmp(key, "light_stab") == 0) g_feed_lightstab_cfg.enabled = iv ? 1 : 0;
@@ -1133,6 +1143,7 @@ static bool CfgReload()
     if (next.reset_mode < 0 || next.reset_mode > 2) next.reset_mode = FeedReset_Adaptive;
     if (next.reset_every) next.reset_mode = FeedReset_Every;
     g_feed_adapt_cfg.reset_mode = next.reset_mode;
+    FeedAsyncUpdateLagMetric();
 
     const bool rebuild = next.hdr != g_cfg.hdr || next.depth_inverted != g_cfg.depth_inverted ||
                          next.flags != g_cfg.flags || next.rebuild != g_cfg.rebuild ||
@@ -1165,6 +1176,7 @@ static const char *const kCfgSavedKeys[] = {
     "mv_scale_x", "mv_scale_y", "stall_log_ms",
     "ofa_enabled", "ofa_grid", "ofa_perf", "engine_velocity", "velocity_cand", "velocity_decode", "velocity_scale",
     "early_color", "early_color_cand",
+    "async_feed", "key_async_feed", "hud_stats", "key_hud",
     "log_detail", "log_detail_every", "light_stab", "light_stab_strength", "light_stab_max_delta",
     "adapt_mask_thr", "adapt_mask_thr_vel", "adapt_luma_thr", "evaluate_stride",
     "quality_preset", "auto_profile_applied", "auto_profile",
@@ -1225,6 +1237,7 @@ static void CfgSave()
             "ofa_enabled=%d\nofa_grid=%d\nofa_perf=%d\nengine_velocity=%d\n"
             "velocity_cand=%d\nvelocity_decode=%d\nvelocity_scale=%.3f\n"
             "early_color=%d\nearly_color_cand=%d\n"
+            "async_feed=%d\nkey_async_feed=%d\nhud_stats=%d\nkey_hud=%d\n"
             "log_detail=%d\nlog_detail_every=%d\n"
             "light_stab=%d\nlight_stab_strength=%.3f\nlight_stab_max_delta=%.3f\n"
             "adapt_mask_thr=%.3f\nadapt_mask_thr_vel=%.3f\nadapt_luma_thr=%.3f\n"
@@ -1238,6 +1251,7 @@ static void CfgSave()
             g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
             g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
             g_feed_early_color_cfg.enabled, g_feed_early_color_cfg.cand,
+            g_feed_async_cfg.enabled, g_feed_async_cfg.key, g_feed_hud_cfg.enabled, g_feed_hud_cfg.key,
             g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
             g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
             g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
@@ -2863,6 +2877,9 @@ static void Barrier(ID3D12Resource *res, D3D12_RESOURCE_STATES from, D3D12_RESOU
 
 static void ReleaseFrameResources()
 {
+    // Async worker may still be reading/writing shared slots — wait briefly, then drop display.
+    for (int i = 0; i < 400 && FeedAsyncBusy(); ++i) Sleep(5);
+    FeedAsyncReleaseDisplay();
     // The private fence retires D3D12 only. Vulkan may still have copy-home
     // commands referencing these imports (including on the immediate list).
     if (g.vk.ok && g.rs_queue && (g.vk_img[SLOT_COLOR] || g_vk_probe.dev)) g.rs_queue->wait_idle();
@@ -4112,6 +4129,8 @@ fail:
 
 static void ShutdownSession()
 {
+    FeedAsyncShutdownWorker();
+    FeedAsyncReleaseDisplay();
     FeedOfaShutdown();
     FeedAdaptRelease();
     FeedLightStabRelease();
@@ -5158,7 +5177,8 @@ static void UpdateFsrConstants(ID3D11DeviceContext *ctx, UINT in_w, UINT in_h)
 // upsamples into easu_tex and RCAS sharpens from there into the backbuffer; at 100% EASU
 // has nothing to do and RCAS runs alone straight from the Output; with sharpness 0 EASU
 // writes the backbuffer directly. Either way the game and ReShade never see a size change.
-static void BlitOutputToBackbuffer(ID3D11DeviceContext *ctx, ID3D11RenderTargetView *rtv)
+static void BlitOutputToBackbuffer(ID3D11DeviceContext *ctx, ID3D11RenderTargetView *rtv,
+                                   ID3D11ShaderResourceView *src_override = nullptr)
 {
     // Save what we touch; ReShade rebinds its own state for every following pass anyway.
     ID3D11RenderTargetView   *old_rtv = nullptr;
@@ -5193,8 +5213,8 @@ static void BlitOutputToBackbuffer(ID3D11DeviceContext *ctx, ID3D11RenderTargetV
     const UINT out_h = g.output_height != 0 ? g.output_height : g.height;
     const bool scaled = out_w != g.backbuffer_width || out_h != g.backbuffer_height;
     const bool fsr    = g_cfg.work_upscale != 0 && g.fsr_ok && g.easu_ps != nullptr;
-    const bool easu   = fsr && scaled && g.easu_rtv != nullptr;
-    const bool rcas   = fsr && g_cfg.work_sharpness > 0.0f && (easu || !scaled);   // RCAS reads at native texel indices
+    const bool easu   = fsr && scaled && g.easu_rtv != nullptr && src_override == nullptr;
+    const bool rcas   = fsr && g_cfg.work_sharpness > 0.0f && (easu || !scaled) && src_override == nullptr;
 
     D3D11_VIEWPORT vp = {};
     vp.Width    = static_cast<float>(g.backbuffer_width);
@@ -5215,7 +5235,7 @@ static void BlitOutputToBackbuffer(ID3D11DeviceContext *ctx, ID3D11RenderTargetV
         ctx->PSSetConstantBuffers(0, 1, &g.fsr_cb);
     }
 
-    ID3D11ShaderResourceView *src = g.output_srv;
+    ID3D11ShaderResourceView *src = src_override != nullptr ? src_override : g.output_srv;
     if (easu)
     {
         ID3D11RenderTargetView *target[] = { rcas ? g.easu_rtv : rtv };
@@ -5258,6 +5278,8 @@ static void BlitOutputToBackbuffer(ID3D11DeviceContext *ctx, ID3D11RenderTargetV
 // Per frame
 // ---------------------------------------------------------------------------
 
+#include "feed_hud.h"
+
 static void TimingTick(LONGLONG entry, LONGLONG exit)
 {
     if (g.qpf == 0)
@@ -5285,6 +5307,7 @@ static void TimingTick(LONGLONG entry, LONGLONG exit)
     {
         const double iv_ms = 1000.0 * double(interval) / double(g.qpf);
         FeedPerfTick(iv_ms);
+        FeedHudOnInterval(iv_ms);
     }
 
     if (interval > g.win_max_interval) g.win_max_interval = interval;
@@ -6540,6 +6563,140 @@ static void FeedFrameGl(reshade::api::effect_runtime *rt, reshade::api::command_
 }
 
 // ---------------------------------------------------------------------------
+// D3D11 async feed: worker runs NGX evaluate off the Present thread.
+// ---------------------------------------------------------------------------
+
+static bool FeedAsyncEvaluateJob(float vel_scale_x, float vel_scale_y)
+{
+    if (!g.session_ready || g.feature == nullptr || g.ctx4 == nullptr || g.queue == nullptr)
+        return false;
+    if (g.dev11 == nullptr || g.tex11[SLOT_OUTPUT] == nullptr)
+        return false;
+
+    ID3D11DeviceContext *ctx = nullptr;
+    g.dev11->GetImmediateContext(&ctx);
+    if (ctx == nullptr)
+        return false;
+
+    FeedAsyncEnsureDisplay(g.dev11, g.tex11[SLOT_OUTPUT]);
+
+    bool ok = true;
+    if (!BeginCommands()) { FeedFail("command list"); ok = false; }
+    else
+    {
+        if (g_async_job_input_fence != 0)
+            g.queue->Wait(g.fence12, g_async_job_input_fence);
+        FeedBeginPhase(g.list, L"dlss5-feed copy-in");
+        Barrier(g.tex12[SLOT_COLOR],  D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        Barrier(g.tex12[SLOT_DEPTH],  D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        Barrier(g.tex12[SLOT_MV],     D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        if (g.mask_ok) Barrier(g.tex12[SLOT_MASK], D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        GuideProbeRecord(g.tex12[SLOT_MV], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                         g.tex12[SLOT_DEPTH], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        ID3D12Resource *const nr_out = g.out_scratch != nullptr ? g.out_scratch : g.tex12[SLOT_OUTPUT];
+        Barrier(nr_out, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        FeedEndPhase(g.list);
+
+        const int reset = FeedAdaptResolveReset(g.need_reset);
+        g.need_reset = false;
+
+        NVSDK_NGX_D3D12_DLSS_Eval_Params ep = {};
+        ep.Feature.pInColor  = g.tex12[SLOT_COLOR];
+        ep.Feature.pInOutput = nr_out;
+        ep.Feature.InSharpness = 0.0f;
+        ep.pInDepth          = g.tex12[SLOT_DEPTH];
+        ep.pInMotionVectors  = g.tex12[SLOT_MV];
+        ep.pInBiasCurrentColorMask = g.mask_ok ? g.tex12[SLOT_MASK] : nullptr;
+        ep.InJitterOffsetX   = g.sr_active ? static_cast<float>(g_cfg.jitter_sign) * g.jitter_x : 0.0f;
+        ep.InJitterOffsetY   = g.sr_active ? static_cast<float>(g_cfg.jitter_sign) * g.jitter_y : 0.0f;
+        ep.InRenderSubrectDimensions.Width  = g.width;
+        ep.InRenderSubrectDimensions.Height = g.height;
+        ep.InReset           = reset;
+        ep.InMVScaleX        = vel_scale_x;
+        ep.InMVScaleY        = vel_scale_y;
+        ep.InPreExposure     = 1.0f;
+        ep.InExposureScale   = 1.0f;
+
+        DWORD ecode = 0;
+        FeedBeginPhase(g.list, L"dlss5-feed ngx-evaluate");
+        NVSDK_NGX_Result re = SafeEvaluateDLSS(&ep, &ecode);
+        if (ecode == 0) FeedEndPhase(g.list);
+
+        if (ecode != 0)
+        {
+            AbortCommands();
+            Log("[feed] async evaluate raised exception 0x%08X (caught; nothing was submitted)", ecode);
+            FeedDisable("the DLSS evaluate crashed (the DLSS 5 add-on may be incompatible with this game/resolution)");
+            g.frame_ready = false;
+            ok = false;
+        }
+        else
+        {
+            FeedBeginPhase(g.list, L"dlss5-feed copy-home");
+            Barrier(g.tex12[SLOT_COLOR],  D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COMMON);
+            Barrier(g.tex12[SLOT_DEPTH],  D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COMMON);
+            Barrier(g.tex12[SLOT_MV],     D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COMMON);
+            if (g.mask_ok) Barrier(g.tex12[SLOT_MASK], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COMMON);
+            if (g.out_scratch != nullptr)
+            {
+                Barrier(g.out_scratch, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+                g.list->CopyResource(g.tex12[SLOT_OUTPUT], g.out_scratch);
+            }
+            else
+                Barrier(g.tex12[SLOT_OUTPUT], D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COMMON);
+            FeedEndPhase(g.list);
+            const UINT64 v_out = EndCommands();
+
+            if (NVSDK_NGX_FAILED(re) || v_out == 0)
+            {
+                Log("[feed] async evaluate failed 0x%08X (%s)", re, NgxResultName(re));
+                FeedFail("evaluate");
+                g.frame_ready = false;
+                ok = false;
+            }
+            else
+            {
+                g.ctx4->Wait(g.fence11, v_out);
+                if (g.output_srv != nullptr)
+                {
+                    ID3D11ShaderResourceView *mv_work_srv = nullptr;
+                    if (g.tex11[SLOT_MV] != nullptr)
+                    {
+                        D3D11_SHADER_RESOURCE_VIEW_DESC svd = {};
+                        svd.Format = DXGI_FORMAT_R16G16_FLOAT;
+                        svd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+                        svd.Texture2D.MipLevels = 1;
+                        g.dev11->CreateShaderResourceView(g.tex11[SLOT_MV], &svd, &mv_work_srv);
+                    }
+                    const UINT ow = g.output_width != 0 ? g.output_width : g.width;
+                    const UINT oh = g.output_height != 0 ? g.output_height : g.height;
+                    FeedLightStabApply(g.dev11, ctx, g.tex11[SLOT_OUTPUT], g.output_srv,
+                                       g.tex11[SLOT_MV], mv_work_srv, ow, oh);
+                    if (mv_work_srv) mv_work_srv->Release();
+                }
+                FeedAsyncCopyOutputToDisplay(ctx);
+                const UINT64 n = ++g.frames_done;
+                g.consecutive_fails = 0;
+                if (g.sr_active) ++g.jitter_index;
+                FeedDiagOnFrame(n, reset, g.mask_ok, g.backbuffer_width, g.backbuffer_height, g.width, g.height);
+                if (WarmupRebuildDue(n))
+                {
+                    g.warmup_done = true;
+                    g.frame_ready = false;
+                    Log("[feed] warm-up: re-creating the DLSS feature once (frame %llu, async)", n);
+                }
+            }
+        }
+    }
+    ctx->Release();
+    return ok;
+}
+
+#define FEED_ASYNC_IMPL
+#include "feed_async.h"
+#undef FEED_ASYNC_IMPL
+
+// ---------------------------------------------------------------------------
 // Per frame, D3D11: the original private-device transport
 // ---------------------------------------------------------------------------
 
@@ -6547,6 +6704,9 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
 {
     LARGE_INTEGER t0, t1;
     QueryPerformanceCounter(&t0);
+    FeedPollConfigHotkeys();
+    FeedAsyncNoteGameProc();
+    FeedAsyncUpdateLagMetric();
 
     reshade::api::device *dev_api = rt->get_device();
 
@@ -6556,6 +6716,8 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
     if (ApplyPendingWorkResolution()) g.frame_ready = false;
     if ((g.frames_done % 60) == 0 && CfgReload()) g.frame_ready = false;
     if (!g_cfg.enabled || g_cfg.mode == 0) return;
+
+    const bool async_on = g_feed_async_cfg.enabled != 0 && g_cfg.mode >= 2;
 
     // Inputs from ReShade: the frame being processed, and the companion effect's guide textures.
     reshade::api::resource_view color_srv = {}, color_srgb = {}, mv_srv = {}, mv_srgb = {}, d_srv = {}, d_srgb = {};
@@ -6747,6 +6909,21 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
         else g.consecutive_fails = 0;
     }
 
+    // Async: if the worker still owns SLOT_*, skip capture/evaluate and only show N-1.
+    if (ok && async_on && FeedAsyncBusy())
+    {
+        if (FeedAsyncHasDisplay())
+            BlitOutputToBackbuffer(ctx, rtv11, g_async_display_srv);
+        SafeRelease(color);
+        SafeRelease(early_color);
+        SafeRelease(mv);
+        SafeRelease(depth);
+        SafeRelease(mask);
+        QueryPerformanceCounter(&t1);
+        TimingTick(t0.QuadPart, t1.QuadPart);
+        return;
+    }
+
     if (ok)
     {
         // work_upscale=2: this frame's grid shift. The sequence restarts with the DLSS
@@ -6794,6 +6971,21 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
             if (g.tex11[SLOT_OUTPUT] != nullptr)
                 BlitOutputToBackbuffer(ctx, rtv11);
             ++g.frames_done;
+        }
+        else if (ok && async_on)
+        {
+            // Fast path: capture done; kick worker; display last completed (N-1).
+            if (g.dev11 != nullptr && g.tex11[SLOT_OUTPUT] != nullptr)
+                FeedAsyncEnsureDisplay(g.dev11, g.tex11[SLOT_OUTPUT]);
+            const UINT64 v_in = ++g.fence_value;
+            g.ctx4->Signal(g.fence11, v_in);
+            ctx->Flush();
+            if (!FeedAsyncTrySubmit(vel_scale_x, vel_scale_y, v_in))
+            {
+                // Should be rare: busy race after the early-out above.
+            }
+            if (FeedAsyncHasDisplay())
+                BlitOutputToBackbuffer(ctx, rtv11, g_async_display_srv);
         }
         else if (ok)
         {
@@ -7506,6 +7698,42 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
         ImGui::TextDisabled("evaluate_stride=%d (half-rate duty)", g_feed_auto.evaluate_stride);
 
     ImGui::Separator();
+    ImGui::TextUnformatted("Async feed (D3D11)");
+    {
+        bool async_on = g_feed_async_cfg.enabled != 0;
+        if (ImGui::Checkbox("Async feed (~1 frame display lag)", &async_on))
+        {
+            g_feed_async_cfg.enabled = async_on ? 1 : 0;
+            FeedAsyncUpdateLagMetric();
+            dirty = true;
+        }
+        ImGui::SameLine(); HelpMarker(
+            "Present captures inputs only and does not wait on NGX Evaluate. "
+            "A worker on other cores finishes NR; the game shows the last completed frame (N-1). "
+            "display_lag_frames=1. Off by default. Hotkey: key_async_feed (default F10).\n\n"
+            "Vulkan: use async_home instead (already in cfg) — different mechanism; do not set async_feed on Vulkan.");
+        if (g_feed_async_cfg.enabled)
+            ImGui::TextColored(ImVec4(0.55f, 0.85f, 1.0f, 1.0f),
+                               "Async feed ON · display lag ~1 frame");
+        else
+            ImGui::TextDisabled("display_lag_frames = %d", g_display_lag_frames);
+        if (rt != nullptr && rt->get_device()->get_api() == reshade::api::device_api::vulkan)
+            ImGui::TextDisabled("Vulkan tip: async_home=%d already covers present-path lag hiding.", g_cfg.async_home);
+    }
+    {
+        bool hud_on = g_feed_hud_cfg.enabled != 0;
+        if (ImGui::Checkbox("In-game HUD stats", &hud_on))
+        {
+            g_feed_hud_cfg.enabled = hud_on ? 1 : 0;
+            dirty = true;
+        }
+        ImGui::SameLine(); HelpMarker(
+            "Top-right FPS / CPU / GPU feed / async panel without opening full Home. "
+            "Also enable Add-ons → \"DLSS 5 Feed · HUD\" once so it draws with Home closed. "
+            "Hotkey: key_hud (default F9).");
+    }
+
+    ImGui::Separator();
     ImGui::TextUnformatted("Status");
     ImGui::Text("Session: %s", g.disabled ? "disabled" : g.session_ready ? "open" : "not started");
     if (g.disabled && g_disable_why[0])
@@ -8014,6 +8242,7 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
         reshade::register_event<reshade::addon_event::draw>(OnDraw);
         reshade::register_event<reshade::addon_event::draw_indexed>(OnDrawIndexed);
         reshade::register_overlay(nullptr, DrawOverlay);
+        reshade::register_overlay("DLSS 5 Feed · HUD", DrawFeedHudPanel);
     }
     else if (reason == DLL_PROCESS_DETACH)
     {
@@ -8031,6 +8260,7 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
             DeleteCriticalSection(&g_log_cs);
             return TRUE;
         }
+        reshade::unregister_overlay("DLSS 5 Feed · HUD", DrawFeedHudPanel);
         reshade::unregister_overlay(nullptr, DrawOverlay);
         reshade::unregister_event<reshade::addon_event::create_device>(OnCreateDevice);
         reshade::unregister_event<reshade::addon_event::init_effect_runtime>(OnInitEffectRuntime);
@@ -8048,6 +8278,7 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID)
         FeedVkFramePresentRemove();
         FeedVkHookRemove();   // before this code is unmapped -- ReShade reloads add-ons per Vulkan instance
         g_ngx_dying = true;   // process is exiting: never call back into NGX
+        FeedAsyncShutdownWorker();
         ShutdownSession();
         reshade::unregister_addon(module);
         Log("shut down cleanly.");

--- a/src/dlss5-feed.cpp
+++ b/src/dlss5-feed.cpp
@@ -139,6 +139,7 @@ static void Warn(const char *fmt, ...)
 // which it is not: the useful half of the line is the faulting module (issue #44).
 #include "feed_ofa.h"
 #include "feed_velocity.h"
+#include "feed_early_color.h"
 #include "feed_adapt.h"
 #include "feed_lightstab.h"
 
@@ -984,6 +985,8 @@ static void CfgWriteDefault()
             "velocity_cand=%d\n"
             "velocity_decode=%d\n"
             "velocity_scale=%.3f\n"
+            "early_color=%d\n"
+            "early_color_cand=%d\n"
             "log_detail=%d\n"
             "log_detail_every=%d\n"
             "light_stab=%d\n"
@@ -1004,6 +1007,7 @@ static void CfgWriteDefault()
             g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms,
             g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
             g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
+            g_feed_early_color_cfg.enabled, g_feed_early_color_cfg.cand,
             g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
             g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
             g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
@@ -1092,6 +1096,8 @@ static bool CfgReload()
             g_feed_velocity_cfg.decode = (iv < 0 || iv > 3) ? FeedVelDecode_Auto : iv;
         else if (_stricmp(key, "velocity_scale") == 0)
             g_feed_velocity_cfg.scale = (val < 0.05f) ? 0.05f : (val > 8.f ? 8.f : val);
+        else if (_stricmp(key, "early_color") == 0) g_feed_early_color_cfg.enabled = iv ? 1 : 0;
+        else if (_stricmp(key, "early_color_cand") == 0) g_feed_early_color_cfg.cand = iv;
         else if (_stricmp(key, "log_detail") == 0) g_feed_diag_cfg.enabled = iv ? 1 : 0;
         else if (_stricmp(key, "log_detail_every") == 0) g_feed_diag_cfg.every_n = iv > 0 ? iv : 60;
         else if (_stricmp(key, "light_stab") == 0) g_feed_lightstab_cfg.enabled = iv ? 1 : 0;
@@ -1158,6 +1164,7 @@ static const char *const kCfgSavedKeys[] = {
     "work_sharpness", "gpu_timeout_ms", "buffer_home", "async_home", "sync_home",
     "mv_scale_x", "mv_scale_y", "stall_log_ms",
     "ofa_enabled", "ofa_grid", "ofa_perf", "engine_velocity", "velocity_cand", "velocity_decode", "velocity_scale",
+    "early_color", "early_color_cand",
     "log_detail", "log_detail_every", "light_stab", "light_stab_strength", "light_stab_max_delta",
     "adapt_mask_thr", "adapt_mask_thr_vel", "adapt_luma_thr", "evaluate_stride",
     "quality_preset", "auto_profile_applied", "auto_profile",
@@ -1217,6 +1224,7 @@ static void CfgSave()
             "buffer_home=%d\nasync_home=%d\nsync_home=%d\nmv_scale_x=%.3f\nmv_scale_y=%.3f\nstall_log_ms=%d\n"
             "ofa_enabled=%d\nofa_grid=%d\nofa_perf=%d\nengine_velocity=%d\n"
             "velocity_cand=%d\nvelocity_decode=%d\nvelocity_scale=%.3f\n"
+            "early_color=%d\nearly_color_cand=%d\n"
             "log_detail=%d\nlog_detail_every=%d\n"
             "light_stab=%d\nlight_stab_strength=%.3f\nlight_stab_max_delta=%.3f\n"
             "adapt_mask_thr=%.3f\nadapt_mask_thr_vel=%.3f\nadapt_luma_thr=%.3f\n"
@@ -1229,6 +1237,7 @@ static void CfgSave()
             g_cfg.sync_home, g_cfg.mv_scale_x, g_cfg.mv_scale_y, g_cfg.stall_log_ms,
             g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf, g_feed_velocity_cfg.enabled,
             g_feed_velocity_cfg.cand, g_feed_velocity_cfg.decode, g_feed_velocity_cfg.scale,
+            g_feed_early_color_cfg.enabled, g_feed_early_color_cfg.cand,
             g_feed_diag_cfg.enabled, g_feed_diag_cfg.every_n,
             g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength, g_feed_lightstab_cfg.max_delta,
             g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
@@ -4108,6 +4117,9 @@ static void ShutdownSession()
     FeedLightStabRelease();
     FeedVelocityReleaseOut();
     FeedVelocityReleaseBlit();
+    FeedEarlyColorReleaseOut();
+    FeedEarlyColorReleaseSnap();
+    FeedEarlyColorReleaseBlit();
     ReleaseFrameResources();
     if (g.params != nullptr) { if (!g_ngx_dying) NVSDK_NGX_D3D12_DestroyParameters(g.params); g.params = nullptr; }
     if (g.ngx_inited && g.dev12 != nullptr) { if (!g_ngx_dying) NVSDK_NGX_D3D12_Shutdown1(g.dev12); g.ngx_inited = false; }
@@ -6589,6 +6601,7 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
 
     // Phase 3: engine velocity RT hunter (cfg: engine_velocity=1). Wins over OFA / Lumenite.
     FeedVelocityBeginFrame(cd.Width, cd.Height);
+    FeedEarlyColorBeginFrame(cd.Width, cd.Height);
     if (g_feed_velocity_cfg.enabled && (g.frames_done % 120) == 1)
         FeedVelocityTryBind(rt, cd.Width, cd.Height);
     float vel_scale_x = g_cfg.mv_scale_x, vel_scale_y = g_cfg.mv_scale_y;
@@ -6614,6 +6627,21 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
         }
     }
 
+    // Early color: optional SceneColor snap → SLOT_COLOR (else Present backbuffer).
+    ID3D11Texture2D *early_color = nullptr;
+    if (g_feed_early_color_cfg.enabled)
+    {
+        ID3D11Device *edev = nullptr;
+        ctx->GetDevice(&edev);
+        if (edev != nullptr)
+        {
+            early_color = FeedEarlyColorAcquire(edev, ctx, cd.Width, cd.Height, cd.Format);
+            FeedEarlyColorAfterAcquire();
+            edev->Release();
+        }
+    }
+    ID3D11Texture2D *color_in = early_color != nullptr ? early_color : color;
+
     {
         const bool ofa_cap = true; // D3D11 feed path
         FeedAutoProfileTick(g.frames_done, ofa_cap);
@@ -6625,7 +6653,7 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
         ctx->GetDevice(&ofa_dev);
         if (ofa_dev != nullptr)
         {
-            if (ID3D11Texture2D *ofa_mv = FeedOfaUpdate(ofa_dev, ctx, color, cd.Format, cd.Width, cd.Height))
+            if (ID3D11Texture2D *ofa_mv = FeedOfaUpdate(ofa_dev, ctx, color_in, cd.Format, cd.Width, cd.Height))
             {
                 SafeRelease(mv);
                 mv = ofa_mv;
@@ -6730,7 +6758,7 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
             HaltonJitter(g.jitter_index, g.jitter_phases, &g.jitter_x, &g.jitter_y);
         }
         Breadcrumb("preparing work-resolution inputs");
-        ok = CopyOrResampleInputs(ctx, color, mv, depth, mask,
+        ok = CopyOrResampleInputs(ctx, color_in, mv, depth, mask,
                                   nullptr,
                                   reinterpret_cast<ID3D11ShaderResourceView *>(mv_srv.handle),
                                   reinterpret_cast<ID3D11ShaderResourceView *>(d_srv.handle),
@@ -6914,6 +6942,7 @@ static void FeedFrame11(reshade::api::effect_runtime *rt, reshade::api::command_
     }
 
     SafeRelease(color);
+    SafeRelease(early_color);
     SafeRelease(mv);
     SafeRelease(depth);
     SafeRelease(mask);
@@ -7767,6 +7796,52 @@ static void DrawOverlay(reshade::api::effect_runtime *rt)
         ImGui::TextDisabled("Enable Motion Blur in-game if the list stays empty");
     }
 
+    ImGui::Separator();
+    ImGui::TextUnformatted("Early color (D3D11 SceneColor snap)");
+    bool early_on = g_feed_early_color_cfg.enabled != 0;
+    if (ImGui::Checkbox("Hunt & feed early color RT (off by default)", &early_on))
+    { g_feed_early_color_cfg.enabled = early_on ? 1 : 0; dirty = true; }
+    ImGui::SameLine(); HelpMarker(
+        "Tracks full-res HDR/RGBA SceneColor-like RTs mid-frame. When a fresh snap exists, "
+        "NR feeds from that snap instead of the Present backbuffer (less double-TAA). "
+        "MVP still blits NR over the backbuffer — UI/HUD may be missing. "
+        "Fallback: Present path. Cfg: early_color / early_color_cand.");
+    {
+        const bool early_active = g_feed_early_color.using_early;
+        ImGui::TextColored(
+            early_active ? ImVec4(0.5f, 0.9f, 0.5f, 1.0f) : ImVec4(0.75f, 0.75f, 0.55f, 1.0f),
+            "Color path: %s", g_feed_early_color.status_line[0] ? g_feed_early_color.status_line : "fallback Present");
+        ImGui::TextWrapped("%s", g_feed_early_color.overlay_line[0] ? g_feed_early_color.overlay_line : "");
+        ImGui::TextDisabled("Candidates: %d", g_feed_early_color.cand_count);
+        if (g_feed_early_color.cand_count > 0)
+        {
+            static char elabels[32][96];
+            static const char *eptrs[33];
+            int n = 0;
+            _snprintf_s(elabels[0], sizeof(elabels[0]), _TRUNCATE, "Auto (best score)");
+            eptrs[n++] = elabels[0];
+            const int max_show = g_feed_early_color.cand_count < 31 ? g_feed_early_color.cand_count : 31;
+            for (int i = 0; i < max_show; ++i)
+            {
+                const FeedEarlyColorCand &c = g_feed_early_color.cands[i];
+                _snprintf_s(elabels[i + 1], sizeof(elabels[i + 1]), _TRUNCATE,
+                            "#%d %s %ux%u score=%d%s", i, FeedEarlyColorFmtLabel(c.fmt),
+                            c.width, c.height, c.score, c.name_hit ? " *" : "");
+                eptrs[i + 1] = elabels[i + 1];
+                n++;
+            }
+            int sel = g_feed_early_color_cfg.cand < 0 ? 0 : g_feed_early_color_cfg.cand + 1;
+            if (sel >= n) sel = 0;
+            if (ImGui::Combo("Early color candidate", &sel, eptrs, n))
+            {
+                g_feed_early_color_cfg.cand = (sel <= 0) ? -1 : sel - 1;
+                dirty = true;
+            }
+        }
+        if (ImGui::Button("Rescan early color RTs"))
+        { FeedEarlyColorClearCands(); dirty = true; }
+    }
+
     ImGui::TextWrapped("Change the provider with DLSS5_Feed.fx's DLSS5_MV_PROVIDER preprocessor definition: "
                        "0 texMotionVectors (qUINT, dh_uber_motion), 1 Launchpad, 2 VORT, 3 LumeniteFX Kernel, 4 LumeniteFX QuantMotion.");
     if (ImGui::SliderFloat("MV scale X", &g_cfg.mv_scale_x, 0.0f, 4.0f)) dirty = true;
@@ -7809,18 +7884,21 @@ static void OnBindRenderTargets(reshade::api::command_list *cmd_list, uint32_t c
                                 const reshade::api::resource_view *rtvs, reshade::api::resource_view dsv)
 {
     FeedVelocityOnBindRTs(cmd_list, count, rtvs, dsv);
+    FeedEarlyColorOnBindRTs(cmd_list, count, rtvs, dsv);
 }
 
 static bool OnDraw(reshade::api::command_list *cmd_list, uint32_t /*vertices*/, uint32_t /*instances*/,
                    uint32_t /*first_vertex*/, uint32_t /*first_instance*/)
 {
-    return FeedVelocityOnDraw(cmd_list);
+    FeedVelocityOnDraw(cmd_list);
+    return FeedEarlyColorOnDraw(cmd_list);
 }
 
 static bool OnDrawIndexed(reshade::api::command_list *cmd_list, uint32_t /*indices*/, uint32_t /*instances*/,
                           uint32_t /*first_index*/, int32_t /*vertex_offset*/, uint32_t /*first_instance*/)
 {
-    return FeedVelocityOnDraw(cmd_list);
+    FeedVelocityOnDraw(cmd_list);
+    return FeedEarlyColorOnDraw(cmd_list);
 }
 
 static void OnInitResource(reshade::api::device *device, const reshade::api::resource_desc &desc,
@@ -7828,11 +7906,13 @@ static void OnInitResource(reshade::api::device *device, const reshade::api::res
                            reshade::api::resource resource)
 {
     FeedVelocityOnInitResource(device, desc, resource);
+    FeedEarlyColorOnInitResource(device, desc, resource);
 }
 
 static void OnDestroyResource(reshade::api::device *, reshade::api::resource resource)
 {
     FeedVelocityOnDestroyResource(resource);
+    FeedEarlyColorOnDestroyResource(resource);
 }
 
 // Fired by ReShade before the device (for Vulkan: from inside its vkCreateInstance

--- a/src/feed_adapt.h
+++ b/src/feed_adapt.h
@@ -1,0 +1,283 @@
+// feed_adapt.h -- scene-adaptive DLSS history reset (engine-agnostic).
+//
+// Goal: keep the "no ghosting" win of reset_every without always nuking temporal
+// history (which makes lighting flicker). Samples bias-mask coverage + mean luma
+// from the feed's D3D11 work textures and sets InReset when the scene looks unsafe.
+//
+// Include from dlss5-feed.cpp after Log() and D3D11 headers.
+
+#pragma once
+
+#include <cmath>
+#include <cstring>
+#include <cstdint>
+
+enum FeedResetMode
+{
+    FeedReset_Off = 0,       // never (except g.need_reset)
+    FeedReset_Every = 1,     // diagnostic: every frame
+    FeedReset_Adaptive = 2,  // auto by scene metrics (default)
+};
+
+struct FeedAdaptCfg
+{
+    int   reset_mode;      // FeedResetMode; default Adaptive
+    float mask_thr;        // fraction of masked pixels that forces reset
+    float luma_thr;        // relative |Δ mean luma| that forces reset
+    float mask_thr_vel;    // softer when engine velocity is bound
+};
+
+static FeedAdaptCfg g_feed_adapt_cfg = { FeedReset_Adaptive, 0.10f, 0.035f, 0.18f };
+
+struct FeedAdaptState
+{
+    ID3D11Texture2D *stage_mask;
+    ID3D11Texture2D *stage_color;
+    UINT stage_w, stage_h;
+    DXGI_FORMAT stage_color_fmt;
+
+    float mask_avg;
+    float luma_avg;
+    float luma_prev;
+    float luma_delta;
+    bool  have_luma_prev;
+    bool  want_reset;
+    bool  sampled_ok;
+
+    // Rolling: how often we reset (for overlay + soft auto-tune)
+    int   window_n;
+    int   window_resets;
+    float reset_rate;
+
+    char  status[160];
+};
+
+static FeedAdaptState g_feed_adapt = {};
+
+static void FeedAdaptRelease()
+{
+    if (g_feed_adapt.stage_mask) { g_feed_adapt.stage_mask->Release(); g_feed_adapt.stage_mask = nullptr; }
+    if (g_feed_adapt.stage_color) { g_feed_adapt.stage_color->Release(); g_feed_adapt.stage_color = nullptr; }
+    g_feed_adapt.stage_w = g_feed_adapt.stage_h = 0;
+}
+
+static bool FeedAdaptEnsureStaging(ID3D11Device *dev, UINT w, UINT h, DXGI_FORMAT color_fmt)
+{
+    if (dev == nullptr || w == 0 || h == 0) return false;
+    if (g_feed_adapt.stage_mask && g_feed_adapt.stage_color &&
+        g_feed_adapt.stage_w == w && g_feed_adapt.stage_h == h &&
+        g_feed_adapt.stage_color_fmt == color_fmt)
+        return true;
+
+    FeedAdaptRelease();
+
+    D3D11_TEXTURE2D_DESC d = {};
+    d.Width = w; d.Height = h; d.MipLevels = 1; d.ArraySize = 1;
+    d.SampleDesc.Count = 1;
+    d.Usage = D3D11_USAGE_STAGING;
+    d.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+
+    d.Format = DXGI_FORMAT_R8_UNORM;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_adapt.stage_mask)))
+        return false;
+
+    d.Format = color_fmt;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_adapt.stage_color)))
+    {
+        FeedAdaptRelease();
+        return false;
+    }
+
+    g_feed_adapt.stage_w = w;
+    g_feed_adapt.stage_h = h;
+    g_feed_adapt.stage_color_fmt = color_fmt;
+    return true;
+}
+
+static float FeedAdaptLumaFromPixel(const uint8_t *p, DXGI_FORMAT fmt, UINT bpp_guess)
+{
+    // Best-effort for common feed color formats.
+    if (fmt == DXGI_FORMAT_R16G16B16A16_FLOAT || fmt == DXGI_FORMAT_R16G16B16A16_TYPELESS)
+    {
+        // Binary16 approximate: reinterpret high bits roughly — staging of FP16 is 8 bytes/pixel.
+        // Use simple decode: IEEE754 half via bit cast helpers.
+        const uint16_t *h = reinterpret_cast<const uint16_t *>(p);
+        auto half = [](uint16_t v) -> float {
+            const uint32_t s = (v >> 15) & 1u;
+            const uint32_t e = (v >> 10) & 0x1fu;
+            const uint32_t m = v & 0x3ffu;
+            uint32_t o;
+            if (e == 0) o = (s << 31);
+            else if (e == 31) o = (s << 31) | 0x7f800000u | (m << 13);
+            else o = (s << 31) | ((e + 112u) << 23) | (m << 13);
+            float f;
+            memcpy(&f, &o, 4);
+            return f;
+        };
+        const float r = half(h[0]), g = half(h[1]), b = half(h[2]);
+        return 0.2126f * r + 0.7152f * g + 0.0722f * b;
+    }
+    if (fmt == DXGI_FORMAT_R11G11B10_FLOAT)
+    {
+        // Skip precise decode; treat raw as rough energy.
+        const uint32_t v = *reinterpret_cast<const uint32_t *>(p);
+        return (float)((v >> 2) & 0x1fffu) * (1.0f / 8191.0f);
+    }
+    // UNORM 8-bit family (R8G8B8A8, B8G8R8A8, …)
+    (void)bpp_guess;
+    const float r = p[0] * (1.0f / 255.0f);
+    const float g = p[1] * (1.0f / 255.0f);
+    const float b = p[2] * (1.0f / 255.0f);
+    if (fmt == DXGI_FORMAT_B8G8R8A8_UNORM || fmt == DXGI_FORMAT_B8G8R8A8_UNORM_SRGB)
+        return 0.2126f * b + 0.7152f * g + 0.0722f * r;
+    return 0.2126f * r + 0.7152f * g + 0.0722f * b;
+}
+
+// Call after work textures are filled (g.tex11 COLOR/MASK). Cheap sparse CPU sample.
+static void FeedAdaptSample(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                            ID3D11Texture2D *color, ID3D11Texture2D *mask,
+                            bool mask_ok, UINT w, UINT h, bool velocity_bound)
+{
+    g_feed_adapt.sampled_ok = false;
+    g_feed_adapt.want_reset = false;
+    g_feed_adapt.mask_avg = 0.0f;
+    g_feed_adapt.luma_delta = 0.0f;
+
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Off)
+    {
+        _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                    "Reset: off");
+        return;
+    }
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Every)
+    {
+        g_feed_adapt.want_reset = true;
+        _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                    "Reset: every frame (diagnostic)");
+        return;
+    }
+
+    // Adaptive
+    if (dev == nullptr || ctx == nullptr || color == nullptr || w < 8 || h < 8)
+    {
+        _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                    "Reset: adaptive (no sample)");
+        return;
+    }
+
+    D3D11_TEXTURE2D_DESC cd = {};
+    color->GetDesc(&cd);
+    if (!FeedAdaptEnsureStaging(dev, w, h, cd.Format))
+    {
+        _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                    "Reset: adaptive (staging failed)");
+        return;
+    }
+
+    ctx->CopyResource(g_feed_adapt.stage_color, color);
+    if (mask_ok && mask != nullptr)
+        ctx->CopyResource(g_feed_adapt.stage_mask, mask);
+
+    D3D11_MAPPED_SUBRESOURCE mm = {}, mc = {};
+    const bool mask_mapped = mask_ok && mask != nullptr &&
+        SUCCEEDED(ctx->Map(g_feed_adapt.stage_mask, 0, D3D11_MAP_READ, 0, &mm));
+    const bool color_mapped = SUCCEEDED(ctx->Map(g_feed_adapt.stage_color, 0, D3D11_MAP_READ, 0, &mc));
+    if (!color_mapped)
+    {
+        if (mask_mapped) ctx->Unmap(g_feed_adapt.stage_mask, 0);
+        _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                    "Reset: adaptive (map failed)");
+        return;
+    }
+
+    const UINT stride = 24; // ~ (w/24)*(h/24) samples
+    double mask_sum = 0.0, luma_sum = 0.0;
+    int n = 0;
+    const UINT bpp = (cd.Format == DXGI_FORMAT_R16G16B16A16_FLOAT) ? 8u :
+                     (cd.Format == DXGI_FORMAT_R11G11B10_FLOAT) ? 4u : 4u;
+
+    for (UINT y = 0; y < h; y += stride)
+    {
+        const uint8_t *rowc = reinterpret_cast<const uint8_t *>(mc.pData) + y * mc.RowPitch;
+        const uint8_t *rowm = mask_mapped
+            ? reinterpret_cast<const uint8_t *>(mm.pData) + y * mm.RowPitch
+            : nullptr;
+        for (UINT x = 0; x < w; x += stride)
+        {
+            luma_sum += FeedAdaptLumaFromPixel(rowc + x * bpp, cd.Format, bpp);
+            if (rowm) mask_sum += rowm[x] * (1.0 / 255.0);
+            ++n;
+        }
+    }
+
+    if (mask_mapped) ctx->Unmap(g_feed_adapt.stage_mask, 0);
+    ctx->Unmap(g_feed_adapt.stage_color, 0);
+
+    if (n <= 0) return;
+
+    g_feed_adapt.mask_avg = mask_mapped ? (float)(mask_sum / n) : 0.0f;
+    g_feed_adapt.luma_avg = (float)(luma_sum / n);
+    const bool had_luma = g_feed_adapt.have_luma_prev;
+    if (had_luma)
+    {
+        const float base = fmaxf(g_feed_adapt.luma_prev, 1e-3f);
+        g_feed_adapt.luma_delta = fabsf(g_feed_adapt.luma_avg - g_feed_adapt.luma_prev) / base;
+    }
+    else
+        g_feed_adapt.luma_delta = 0.0f;
+    g_feed_adapt.luma_prev = g_feed_adapt.luma_avg;
+    g_feed_adapt.have_luma_prev = true;
+    g_feed_adapt.sampled_ok = true;
+
+    const float mthr = velocity_bound ? g_feed_adapt_cfg.mask_thr_vel : g_feed_adapt_cfg.mask_thr;
+    const bool mask_hot = g_feed_adapt.mask_avg >= mthr;
+    const bool luma_hot = had_luma && g_feed_adapt.luma_delta >= g_feed_adapt_cfg.luma_thr;
+    g_feed_adapt.want_reset = mask_hot || luma_hot;
+
+    // Soft auto-tune: if we reset almost every frame, raise mask thr a bit (prefer lighting
+    // stability); if we almost never reset but mask sits mid, lower thr (prefer anti-ghost).
+    g_feed_adapt.window_n++;
+    if (g_feed_adapt.want_reset) g_feed_adapt.window_resets++;
+    if (g_feed_adapt.window_n >= 90)
+    {
+        g_feed_adapt.reset_rate = (float)g_feed_adapt.window_resets / (float)g_feed_adapt.window_n;
+        if (g_feed_adapt.reset_rate > 0.85f)
+        {
+            g_feed_adapt_cfg.mask_thr = fminf(g_feed_adapt_cfg.mask_thr + 0.01f, 0.35f);
+            g_feed_adapt_cfg.mask_thr_vel = fminf(g_feed_adapt_cfg.mask_thr_vel + 0.01f, 0.45f);
+        }
+        else if (g_feed_adapt.reset_rate < 0.05f && g_feed_adapt.mask_avg > 0.04f)
+        {
+            g_feed_adapt_cfg.mask_thr = fmaxf(g_feed_adapt_cfg.mask_thr - 0.005f, 0.04f);
+            g_feed_adapt_cfg.mask_thr_vel = fmaxf(g_feed_adapt_cfg.mask_thr_vel - 0.005f, 0.08f);
+        }
+        g_feed_adapt.window_n = 0;
+        g_feed_adapt.window_resets = 0;
+    }
+
+    _snprintf_s(g_feed_adapt.status, sizeof(g_feed_adapt.status), _TRUNCATE,
+                "Reset: %s | mask %.0f%% lumaΔ %.1f%% thr %.0f%% %s",
+                g_feed_adapt.want_reset ? "YES" : "calm",
+                g_feed_adapt.mask_avg * 100.0f,
+                g_feed_adapt.luma_delta * 100.0f,
+                mthr * 100.0f,
+                velocity_bound ? "vel" : (mask_ok ? "ofa/lum" : "no-mask"));
+}
+
+static int FeedAdaptResolveReset(bool need_reset)
+{
+    if (need_reset) return 1;
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Every) return 1;
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Adaptive && g_feed_adapt.want_reset) return 1;
+    return 0;
+}
+
+static const char *FeedAdaptResetModeName(int m)
+{
+    switch (m)
+    {
+    case FeedReset_Off: return "Off";
+    case FeedReset_Every: return "Every frame";
+    default: return "Adaptive";
+    }
+}

--- a/src/feed_async.h
+++ b/src/feed_async.h
@@ -1,0 +1,232 @@
+// feed_async.h -- D3D11 async feed (queue depth ≤ 1, display lag ~1 frame).
+//
+// Include once for cfg/state (early). Define FEED_ASYNC_IMPL and include again
+// LATE (after BeginCommands / SafeEvaluateDLSS / Blit / LightStab) for the worker.
+//
+// When async_feed=1 the Present path captures inputs and returns without waiting on
+// NGX Evaluate. A worker on other cores runs Evaluate; Present blits the last completed
+// output (N-1). If the worker is busy, the frame's evaluate is dropped (never queued).
+// Off by default. Vulkan keeps async_home — do not map this knob onto Vulkan.
+
+#ifndef FEED_ASYNC_H_
+#define FEED_ASYNC_H_
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <d3d11.h>
+
+struct FeedAsyncCfg
+{
+    int enabled; // async_feed= 0|1
+    int key;     // key_async_feed= virtual-key (default VK_F10)
+};
+
+static FeedAsyncCfg g_feed_async_cfg = { 0, 0x79 }; // F10
+
+struct FeedHudCfg
+{
+    int enabled; // hud_stats= 0|1
+    int key;     // key_hud= virtual-key (default VK_F9)
+};
+
+static FeedHudCfg g_feed_hud_cfg = { 0, 0x78 }; // F9
+
+// Honest metric: 0 when sync, 1 when async path is active.
+static int g_display_lag_frames = 0;
+
+static ID3D11Texture2D          *g_async_display = nullptr;
+static ID3D11ShaderResourceView *g_async_display_srv = nullptr;
+static volatile long             g_async_display_ready = 0;
+
+static HANDLE        g_async_thread = nullptr;
+static HANDLE        g_async_wake = nullptr;
+static HANDLE        g_async_stop = nullptr;
+static volatile long g_async_busy = 0;
+static volatile long g_async_alive = 0;
+static float         g_async_job_vx = 1.f;
+static float         g_async_job_vy = 1.f;
+static UINT64        g_async_job_input_fence = 0;
+static DWORD         g_async_game_proc = 0;
+
+static bool FeedAsyncBusy()
+{
+    return InterlockedCompareExchange(&g_async_busy, 0, 0) != 0;
+}
+
+static int FeedAsyncDisplayLagFrames()
+{
+    return (g_feed_async_cfg.enabled != 0) ? 1 : 0;
+}
+
+static void FeedAsyncUpdateLagMetric()
+{
+    g_display_lag_frames = FeedAsyncDisplayLagFrames();
+}
+
+static void FeedAsyncNoteGameProc()
+{
+    g_async_game_proc = GetCurrentProcessorNumber();
+}
+
+static void FeedAsyncReleaseDisplay()
+{
+    if (g_async_display_srv) { g_async_display_srv->Release(); g_async_display_srv = nullptr; }
+    if (g_async_display) { g_async_display->Release(); g_async_display = nullptr; }
+    InterlockedExchange(&g_async_display_ready, 0);
+}
+
+static bool FeedAsyncEnsureDisplay(ID3D11Device *dev, ID3D11Texture2D *output_template)
+{
+    if (dev == nullptr || output_template == nullptr)
+        return false;
+    D3D11_TEXTURE2D_DESC td = {};
+    output_template->GetDesc(&td);
+    if (g_async_display != nullptr)
+    {
+        D3D11_TEXTURE2D_DESC cur = {};
+        g_async_display->GetDesc(&cur);
+        if (cur.Width == td.Width && cur.Height == td.Height && cur.Format == td.Format)
+            return g_async_display_srv != nullptr;
+        FeedAsyncReleaseDisplay();
+    }
+    td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+    td.MiscFlags = 0;
+    td.CPUAccessFlags = 0;
+    td.Usage = D3D11_USAGE_DEFAULT;
+    td.MipLevels = 1;
+    td.ArraySize = 1;
+    td.SampleDesc.Count = 1;
+    td.SampleDesc.Quality = 0;
+    if (FAILED(dev->CreateTexture2D(&td, nullptr, &g_async_display)) || g_async_display == nullptr)
+    {
+        Log("[feed] async_feed: display texture create failed");
+        return false;
+    }
+    D3D11_SHADER_RESOURCE_VIEW_DESC svd = {};
+    svd.Format = td.Format;
+    svd.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    svd.Texture2D.MipLevels = 1;
+    if (FAILED(dev->CreateShaderResourceView(g_async_display, &svd, &g_async_display_srv)))
+    {
+        FeedAsyncReleaseDisplay();
+        Log("[feed] async_feed: display SRV create failed");
+        return false;
+    }
+    return true;
+}
+
+static bool FeedAsyncHasDisplay()
+{
+    return InterlockedCompareExchange(&g_async_display_ready, 0, 0) != 0 &&
+           g_async_display_srv != nullptr;
+}
+
+static void FeedAsyncShutdownWorker()
+{
+    if (g_async_stop != nullptr)
+        SetEvent(g_async_stop);
+    if (g_async_thread != nullptr)
+    {
+        WaitForSingleObject(g_async_thread, 5000);
+        CloseHandle(g_async_thread);
+        g_async_thread = nullptr;
+    }
+    if (g_async_wake != nullptr) { CloseHandle(g_async_wake); g_async_wake = nullptr; }
+    if (g_async_stop != nullptr) { CloseHandle(g_async_stop); g_async_stop = nullptr; }
+    InterlockedExchange(&g_async_busy, 0);
+    InterlockedExchange(&g_async_alive, 0);
+    InterlockedExchange(&g_async_display_ready, 0);
+}
+
+// Stub until FEED_ASYNC_IMPL (needs SLOT_OUTPUT / g.tex11).
+static void FeedAsyncCopyOutputToDisplay(ID3D11DeviceContext *ctx);
+
+#endif // FEED_ASYNC_H_
+
+#if defined(FEED_ASYNC_IMPL) && !defined(FEED_ASYNC_IMPL_DONE)
+#define FEED_ASYNC_IMPL_DONE
+
+// Defined just above the FEED_ASYNC_IMPL include in dlss5-feed.cpp.
+static bool FeedAsyncEvaluateJob(float vel_scale_x, float vel_scale_y);
+
+static void FeedAsyncApplyAffinity(HANDLE th)
+{
+    DWORD_PTR proc = 0, sys = 0;
+    if (!GetProcessAffinityMask(GetCurrentProcess(), &proc, &sys) || proc == 0)
+        return;
+    DWORD_PTR mask = proc;
+    if (g_async_game_proc < 64)
+        mask &= ~(static_cast<DWORD_PTR>(1) << g_async_game_proc);
+    if (mask == 0)
+        mask = proc;
+    SetThreadAffinityMask(th, mask);
+}
+
+static DWORD WINAPI FeedAsyncThreadProc(void *)
+{
+    FeedAsyncApplyAffinity(GetCurrentThread());
+    for (;;)
+    {
+        HANDLE waits[2] = { g_async_stop, g_async_wake };
+        const DWORD wr = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
+        if (wr == WAIT_OBJECT_0)
+            break;
+        if (wr != WAIT_OBJECT_0 + 1)
+            continue;
+        FeedAsyncEvaluateJob(g_async_job_vx, g_async_job_vy);
+        InterlockedExchange(&g_async_busy, 0);
+    }
+    InterlockedExchange(&g_async_alive, 0);
+    return 0;
+}
+
+static void FeedAsyncEnsureWorker()
+{
+    if (g_async_thread != nullptr)
+        return;
+    g_async_wake = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    g_async_stop = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (g_async_wake == nullptr || g_async_stop == nullptr)
+        return;
+    InterlockedExchange(&g_async_alive, 1);
+    g_async_thread = CreateThread(nullptr, 0, FeedAsyncThreadProc, nullptr, 0, nullptr);
+    if (g_async_thread == nullptr)
+    {
+        InterlockedExchange(&g_async_alive, 0);
+        CloseHandle(g_async_wake); g_async_wake = nullptr;
+        CloseHandle(g_async_stop); g_async_stop = nullptr;
+        Log("[feed] async_feed: could not start worker thread; staying sync");
+        g_feed_async_cfg.enabled = 0;
+        return;
+    }
+    Log("[feed] async_feed: worker started (display lag ~1 frame when enabled)");
+}
+
+static void FeedAsyncCopyOutputToDisplay(ID3D11DeviceContext *ctx)
+{
+    if (ctx == nullptr || g_async_display == nullptr || g.tex11[SLOT_OUTPUT] == nullptr)
+        return;
+    ctx->CopyResource(g_async_display, g.tex11[SLOT_OUTPUT]);
+    InterlockedExchange(&g_async_display_ready, 1);
+}
+
+// Present: try to hand work to the worker. Returns true if submitted, false if dropped (busy).
+static bool FeedAsyncTrySubmit(float vel_scale_x, float vel_scale_y, UINT64 input_fence)
+{
+    if (g_feed_async_cfg.enabled == 0)
+        return false;
+    FeedAsyncEnsureWorker();
+    if (g_async_thread == nullptr)
+        return false;
+    if (InterlockedCompareExchange(&g_async_busy, 1, 0) != 0)
+        return false; // queue depth ≤ 1: drop, never grow
+    g_async_job_vx = vel_scale_x;
+    g_async_job_vy = vel_scale_y;
+    g_async_job_input_fence = input_fence;
+    SetEvent(g_async_wake);
+    return true;
+}
+
+#endif // FEED_ASYNC_IMPL

--- a/src/feed_autoprofile.h
+++ b/src/feed_autoprofile.h
@@ -1,0 +1,458 @@
+// feed_autoprofile.h -- smart one-shot / Optimize from observed game telemetry.
+//
+// NOT screenshot CV. After settle (or overlay "Optimize"), classify from:
+ //   velocity bind/cands → reset / LightStab / OFA
+ //   mask_avg + reset_rate → flicker / ghosting proxies
+ //   recent frame interval → work% / OFA perf / evaluate_stride (cost pass)
+ // Persists via auto_profile_applied=1 so the next launch skips the probe.
+//
+ // Include after g_cfg / g_feed_* / CfgSave() / Log() exist.
+
+#pragma once
+
+#ifndef FEED_AUTOPROFILE_SETTLE_FRAMES
+#define FEED_AUTOPROFILE_SETTLE_FRAMES 180
+#endif
+#ifndef FEED_AUTOPROFILE_COST_FRAMES
+#define FEED_AUTOPROFILE_COST_FRAMES 90
+#endif
+#ifndef FEED_AUTOPROFILE_METRIC_FRAMES
+#define FEED_AUTOPROFILE_METRIC_FRAMES 60
+#endif
+
+enum FeedAutoProfileKind
+{
+    FeedAuto_None = 0,
+    FeedAuto_EstimatedMv = 1, // no usable engine vectors
+    FeedAuto_EngineMv = 2,    // engine velocity bound with a live cand score
+};
+
+enum FeedAutoPhase
+{
+    FeedAutoPhase_Idle = 0,
+    FeedAutoPhase_Settle = 1,
+    FeedAutoPhase_Metrics = 2, // accumulate mask/reset after MV knobs applied
+    FeedAutoPhase_Cost = 3,    // FPS / frame-time budget pass
+    FeedAutoPhase_Done = 4,
+};
+
+struct FeedAutoProfileState
+{
+    int  applied;          // auto_profile_applied= in cfg (1 = already done)
+    int  kind;             // FeedAutoProfileKind last applied (0 if never)
+    int  settle_frames;    // frames to wait after attach / re-run (default 180)
+    int  force_rerun;      // overlay Optimize / Re-run
+    int  phase;            // FeedAutoPhase
+    int  phase_frames;     // frames spent in current phase
+    int  cost_steps;       // how many work%/OFA cuts applied this run
+    float sum_mask;
+    float sum_reset_rate;
+    float sum_luma;
+    int   metric_n;
+    float sum_frame_ms;
+    int   fps_n;
+    LONGLONG last_qpc;
+    int   evaluate_stride; // 1 = every frame, 2 = half-rate (persisted)
+    char name[48];         // "estimated_mv" / "engine_mv" / "…+cost"
+    char status[160];      // overlay line
+};
+
+static FeedAutoProfileState g_feed_auto = {
+    0, FeedAuto_None, FEED_AUTOPROFILE_SETTLE_FRAMES, 0,
+    FeedAutoPhase_Idle, 0, 0,
+    0.f, 0.f, 0.f, 0,
+    0.f, 0, 0,
+    1,
+    "", ""
+};
+
+static const char *FeedAutoProfileName(int kind)
+{
+    switch (kind)
+    {
+    case FeedAuto_EstimatedMv: return "estimated_mv";
+    case FeedAuto_EngineMv:    return "engine_mv";
+    default:                   return "";
+    }
+}
+
+static int FeedAutoProfileParseName(const char *s)
+{
+    if (s == nullptr || s[0] == '\0') return FeedAuto_None;
+    // Accept "estimated_mv+cost" etc.
+    if (_strnicmp(s, "estimated_mv", 12) == 0) return FeedAuto_EstimatedMv;
+    if (_strnicmp(s, "engine_mv", 9) == 0) return FeedAuto_EngineMv;
+    return FeedAuto_None;
+}
+
+static void FeedAutoProfileMarkCustomized()
+{
+    g_feed_quality_customized = true;
+    g_feed_quality = FeedQuality_Custom;
+}
+
+static void FeedAutoProfileArmProbe(const char *why)
+{
+    g_feed_auto.force_rerun = 1;
+    g_feed_auto.applied = 0;
+    g_feed_auto.kind = FeedAuto_None;
+    g_feed_auto.name[0] = '\0';
+    g_feed_auto.phase = FeedAutoPhase_Settle;
+    g_feed_auto.phase_frames = 0;
+    g_feed_auto.cost_steps = 0;
+    g_feed_auto.sum_mask = g_feed_auto.sum_reset_rate = g_feed_auto.sum_luma = 0.f;
+    g_feed_auto.metric_n = 0;
+    g_feed_auto.sum_frame_ms = 0.f;
+    g_feed_auto.fps_n = 0;
+    g_feed_auto.last_qpc = 0;
+    g_feed_auto.evaluate_stride = 1;
+    g_feed_quality_customized = false;
+    g_feed_quality = FeedQuality_Auto;
+    _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                "Optimize: armed (%s) — settle %d frames",
+                why ? why : "probe", g_feed_auto.settle_frames);
+    Log("[diag] auto_profile: probe armed (%s) settle=%d",
+        why ? why : "probe", g_feed_auto.settle_frames);
+}
+
+static void FeedAutoProfileRequestRerun()
+{
+    FeedAutoProfileArmProbe("re-run");
+}
+
+static void FeedAutoProfileRequestOptimize()
+{
+    FeedAutoProfileArmProbe("optimize");
+}
+
+// Best cand score among current velocity candidates (0 if none).
+static int FeedAutoBestCandScore()
+{
+    int best = 0;
+    for (int i = 0; i < g_feed_velocity.cand_count; ++i)
+        if (g_feed_velocity.cands[i].score > best)
+            best = g_feed_velocity.cands[i].score;
+    return best;
+}
+
+// Branch A — MV quality → base knobs. Does not touch work_resolution (cost pass does).
+static void FeedAutoProfileApplyKind(FeedAutoProfileKind kind, bool ofa_capable_d3d11)
+{
+    g_feed_auto.kind = kind;
+    _snprintf_s(g_feed_auto.name, sizeof(g_feed_auto.name), _TRUNCATE, "%s", FeedAutoProfileName(kind));
+
+    switch (kind)
+    {
+    case FeedAuto_EstimatedMv:
+        // No trusted engine vectors: kill temporal history cache, damp flicker, keep OFA on.
+        g_cfg.reset_mode = FeedReset_Every;
+        g_cfg.reset_every = 1;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Every;
+        g_feed_lightstab_cfg.enabled = 1;
+        g_feed_lightstab_cfg.strength = 0.35f;
+        g_feed_lightstab_cfg.max_delta = 0.06f;
+        g_feed_lightstab_cfg.mv_eps = 0.18f;
+        g_feed_velocity_cfg.enabled = 1; // keep hunting
+        if (ofa_capable_d3d11)
+        {
+            g_feed_ofa_cfg.enabled = 1;
+            if (g_feed_ofa_cfg.grid < 2) g_feed_ofa_cfg.grid = 2;
+            if (g_feed_ofa_cfg.perf != 5 && g_feed_ofa_cfg.perf != 10 && g_feed_ofa_cfg.perf != 20)
+                g_feed_ofa_cfg.perf = 10;
+            if (g_feed_ofa_cfg.perf == 20) g_feed_ofa_cfg.perf = 10; // MEDIUM when OFA is sole MV
+        }
+        else
+        {
+            // DX12-only / no OFA: stay on Every + LightStab; cost pass may lower work%.
+            g_feed_ofa_cfg.enabled = 0;
+        }
+        break;
+
+    case FeedAuto_EngineMv:
+        g_cfg.reset_mode = FeedReset_Adaptive;
+        g_cfg.reset_every = 0;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Adaptive;
+        g_feed_lightstab_cfg.enabled = 0;
+        g_feed_lightstab_cfg.strength = 0.25f;
+        g_feed_lightstab_cfg.max_delta = 0.05f;
+        g_feed_lightstab_cfg.mv_eps = 0.15f;
+        g_feed_velocity_cfg.enabled = 1;
+        if (ofa_capable_d3d11)
+        {
+            g_feed_ofa_cfg.enabled = 1; // fallback if bind drops
+            if (g_feed_ofa_cfg.grid == 0) g_feed_ofa_cfg.grid = 2;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    g_feed_quality_customized = false;
+    g_feed_quality = FeedQuality_Auto;
+    _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                "Optimize: applied %s — measuring residuals…",
+                g_feed_auto.name[0] ? g_feed_auto.name : "none");
+}
+
+// Branch B — ghosting / flicker proxies from adapt metrics (no CV).
+static void FeedAutoProfileApplyResidualHeuristics()
+{
+    if (g_feed_auto.metric_n <= 0) return;
+    const float inv = 1.0f / (float)g_feed_auto.metric_n;
+    const float avg_mask = g_feed_auto.sum_mask * inv;
+    const float avg_rr = g_feed_auto.sum_reset_rate * inv;
+    const float avg_luma = g_feed_auto.sum_luma * inv;
+
+    if (g_feed_adapt_cfg.reset_mode == FeedReset_Adaptive && avg_rr > 0.50f)
+    {
+        g_feed_adapt_cfg.mask_thr = fminf(g_feed_adapt_cfg.mask_thr + 0.04f, 0.35f);
+        g_feed_adapt_cfg.mask_thr_vel = fminf(g_feed_adapt_cfg.mask_thr_vel + 0.04f, 0.45f);
+        g_feed_lightstab_cfg.enabled = 1;
+        g_feed_lightstab_cfg.strength = fmaxf(g_feed_lightstab_cfg.strength, 0.30f);
+        Log("[diag] auto_profile residual: high reset_rate=%.2f → raise mask thr + light_stab", avg_rr);
+    }
+
+    // High mask with modest luma swings ≈ lighting flicker (ME static lamps).
+    if (avg_mask > 0.12f && avg_luma < 0.04f)
+    {
+        g_feed_lightstab_cfg.enabled = 1;
+        g_feed_lightstab_cfg.strength = fmaxf(g_feed_lightstab_cfg.strength, 0.35f);
+        g_feed_lightstab_cfg.max_delta = fmaxf(g_feed_lightstab_cfg.max_delta, 0.06f);
+        Log("[diag] auto_profile residual: mask_avg=%.3f lumaΔ=%.3f → light_stab on",
+            avg_mask, avg_luma);
+    }
+}
+
+// Branch C — FPS / cost. Only moves work%, OFA perf, evaluate_stride.
+// When OFA is off (typical DX12), prefer half-rate stride before work% — same-device
+// DX12 does not currently rebuild at reduced work_resolution.
+static bool FeedAutoProfileCostStep()
+{
+    if (g_feed_auto.fps_n < 30) return false;
+    const float avg_ms = g_feed_auto.sum_frame_ms / (float)g_feed_auto.fps_n;
+    const float fps = avg_ms > 0.1f ? (1000.0f / avg_ms) : 0.f;
+    const float floor_fps = 45.0f;
+    const float panic_fps = 30.0f;
+    if (fps >= floor_fps)
+    {
+        Log("[diag] auto_profile cost: fps=%.1f ok (avg frame %.2f ms)", fps, avg_ms);
+        return false;
+    }
+
+    bool changed = false;
+    const bool ofa_on = g_feed_ofa_cfg.enabled != 0;
+    if (!ofa_on && g_feed_auto.evaluate_stride < 2)
+    {
+        g_feed_auto.evaluate_stride = 2;
+        changed = true;
+        Log("[diag] auto_profile cost: fps=%.1f (no OFA) → evaluate_stride=2", fps);
+    }
+    else if (g_cfg.work_resolution > 70)
+    {
+        const int step = (fps < panic_fps) ? 10 : 5;
+        g_cfg.work_resolution = (g_cfg.work_resolution - step) < 70 ? 70 : (g_cfg.work_resolution - step);
+        changed = true;
+        Log("[diag] auto_profile cost: fps=%.1f → work_resolution=%d%%", fps, g_cfg.work_resolution);
+    }
+    else if (ofa_on && g_feed_ofa_cfg.perf != 20)
+    {
+        g_feed_ofa_cfg.perf = 20;
+        changed = true;
+        Log("[diag] auto_profile cost: fps=%.1f → ofa_perf=FAST", fps);
+    }
+    else if (g_feed_auto.evaluate_stride < 2)
+    {
+        g_feed_auto.evaluate_stride = 2;
+        changed = true;
+        Log("[diag] auto_profile cost: fps=%.1f → evaluate_stride=2 (half-rate)", fps);
+    }
+
+    if (changed)
+    {
+        g_feed_auto.cost_steps++;
+        g_feed_auto.sum_frame_ms = 0.f;
+        g_feed_auto.fps_n = 0;
+        g_feed_auto.last_qpc = 0;
+    }
+    return changed && g_feed_auto.cost_steps < 4 && fps < floor_fps;
+}
+
+static void FeedAutoProfileFinish(bool ofa_capable_d3d11)
+{
+    (void)ofa_capable_d3d11;
+    if (g_feed_auto.cost_steps > 0 && g_feed_auto.name[0])
+    {
+        char base[40];
+        _snprintf_s(base, sizeof(base), _TRUNCATE, "%s", g_feed_auto.name);
+        _snprintf_s(g_feed_auto.name, sizeof(g_feed_auto.name), _TRUNCATE, "%s+cost", base);
+    }
+    g_feed_auto.applied = 1;
+    g_feed_auto.force_rerun = 0;
+    g_feed_auto.phase = FeedAutoPhase_Done;
+    g_feed_quality_customized = false;
+    g_feed_quality = FeedQuality_Auto;
+    _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                "Optimize: %s (work %d%%, ofa g%d/p%d, stride %d)",
+                g_feed_auto.name[0] ? g_feed_auto.name : "done",
+                g_cfg.work_resolution,
+                g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf,
+                g_feed_auto.evaluate_stride);
+    CfgSave();
+    Log("[diag] auto_profile done name=%s reset_mode=%d light_stab=%d ofa=%d grid=%d work=%d stride=%d "
+        "mask_thr=%.3f/%.3f",
+        g_feed_auto.name, g_cfg.reset_mode, g_feed_lightstab_cfg.enabled,
+        g_feed_ofa_cfg.enabled, g_feed_ofa_cfg.grid, g_cfg.work_resolution,
+        g_feed_auto.evaluate_stride,
+        g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel);
+}
+
+static void FeedAutoProfileSampleFps()
+{
+    LARGE_INTEGER now, freq;
+    QueryPerformanceCounter(&now);
+    QueryPerformanceFrequency(&freq);
+    if (g_feed_auto.last_qpc != 0 && freq.QuadPart > 0)
+    {
+        const double ms = 1000.0 * double(now.QuadPart - g_feed_auto.last_qpc) / double(freq.QuadPart);
+        if (ms > 1.0 && ms < 250.0)
+        {
+            g_feed_auto.sum_frame_ms += (float)ms;
+            g_feed_auto.fps_n++;
+        }
+    }
+    g_feed_auto.last_qpc = now.QuadPart;
+}
+
+// Call once per delivered frame from the D3D11 feed path (after velocity try-bind).
+static void FeedAutoProfileTick(UINT64 frames_done, bool ofa_capable_d3d11)
+{
+    const int settle = g_feed_auto.settle_frames > 30 ? g_feed_auto.settle_frames : FEED_AUTOPROFILE_SETTLE_FRAMES;
+
+    if (g_feed_auto.applied && !g_feed_auto.force_rerun)
+    {
+        if (g_feed_auto.status[0] == '\0' && g_feed_auto.name[0])
+            _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                        "Optimize: %s (cached)", g_feed_auto.name);
+        return;
+    }
+
+    // Do not fight a user who already customized before settle finished.
+    if (!g_feed_auto.force_rerun &&
+        (g_feed_quality_customized || g_feed_quality == FeedQuality_Custom))
+    {
+        g_feed_auto.applied = 1;
+        g_feed_auto.phase = FeedAutoPhase_Done;
+        _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                    "Optimize: skipped (customized)");
+        return;
+    }
+
+    if (g_feed_auto.phase == FeedAutoPhase_Idle || g_feed_auto.force_rerun)
+    {
+        if (g_feed_auto.force_rerun || g_feed_auto.phase == FeedAutoPhase_Idle)
+        {
+            if (g_feed_auto.phase == FeedAutoPhase_Idle && !g_feed_auto.force_rerun)
+                g_feed_auto.phase = FeedAutoPhase_Settle;
+        }
+    }
+
+    // ---- Settle: wait for velocity hunt ----
+    // Absolute frame count on first attach; relative phase_frames on Optimize/re-run
+    // (frames_done may already be huge mid-session).
+    if (g_feed_auto.phase <= FeedAutoPhase_Settle)
+    {
+        g_feed_auto.phase = FeedAutoPhase_Settle;
+        const bool rerun = g_feed_auto.force_rerun != 0 || frames_done >= (UINT64)settle;
+        const int need = rerun ? (settle > 90 ? 90 : settle) : settle;
+        if (rerun)
+            g_feed_auto.phase_frames++;
+        const int progress = rerun ? g_feed_auto.phase_frames : (int)frames_done;
+        if (progress < need)
+        {
+            _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                        "Optimize: settling… %d / %d", progress, need);
+            return;
+        }
+
+        const bool bound = g_feed_velocity.bound_ok != 0;
+        const int cands = g_feed_velocity.cand_count;
+        const int best_score = FeedAutoBestCandScore();
+        // Live engine MV: bound + at least one candidate with a meaningful score.
+        const bool engine_ok = bound && g_feed_velocity_cfg.enabled && cands > 0 && best_score >= 8;
+        const FeedAutoProfileKind kind = engine_ok ? FeedAuto_EngineMv : FeedAuto_EstimatedMv;
+
+        FeedAutoProfileApplyKind(kind, ofa_capable_d3d11);
+        Log("[diag] auto_profile MV kind=%s cands=%d bound=%d best_score=%d ofa_cap=%d",
+            g_feed_auto.name, cands, bound ? 1 : 0, best_score, ofa_capable_d3d11 ? 1 : 0);
+
+        g_feed_auto.phase = FeedAutoPhase_Metrics;
+        g_feed_auto.phase_frames = 0;
+        g_feed_auto.sum_mask = g_feed_auto.sum_reset_rate = g_feed_auto.sum_luma = 0.f;
+        g_feed_auto.metric_n = 0;
+        CfgSave(); // early persist of MV knobs
+        return;
+    }
+
+    // ---- Metrics window for residual heuristics ----
+    if (g_feed_auto.phase == FeedAutoPhase_Metrics)
+    {
+        if (g_feed_adapt.sampled_ok)
+        {
+            g_feed_auto.sum_mask += g_feed_adapt.mask_avg;
+            g_feed_auto.sum_reset_rate += g_feed_adapt.reset_rate;
+            g_feed_auto.sum_luma += g_feed_adapt.luma_delta;
+            g_feed_auto.metric_n++;
+        }
+        g_feed_auto.phase_frames++;
+        _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                    "Optimize: residuals… %d / %d",
+                    g_feed_auto.phase_frames, FEED_AUTOPROFILE_METRIC_FRAMES);
+        if (g_feed_auto.phase_frames < FEED_AUTOPROFILE_METRIC_FRAMES)
+            return;
+
+        FeedAutoProfileApplyResidualHeuristics();
+        g_feed_auto.phase = FeedAutoPhase_Cost;
+        g_feed_auto.phase_frames = 0;
+        g_feed_auto.sum_frame_ms = 0.f;
+        g_feed_auto.fps_n = 0;
+        g_feed_auto.last_qpc = 0;
+        g_feed_auto.cost_steps = 0;
+        CfgSave();
+        return;
+    }
+
+    // ---- Cost / FPS pass ----
+    if (g_feed_auto.phase == FeedAutoPhase_Cost)
+    {
+        FeedAutoProfileSampleFps();
+        g_feed_auto.phase_frames++;
+        _snprintf_s(g_feed_auto.status, sizeof(g_feed_auto.status), _TRUNCATE,
+                    "Optimize: cost pass… %d / %d (steps %d)",
+                    g_feed_auto.phase_frames, FEED_AUTOPROFILE_COST_FRAMES, g_feed_auto.cost_steps);
+
+        if (g_feed_auto.phase_frames >= FEED_AUTOPROFILE_COST_FRAMES)
+        {
+            if (FeedAutoProfileCostStep())
+            {
+                // Need another measurement window after a cut.
+                g_feed_auto.phase_frames = 0;
+                CfgSave();
+                return;
+            }
+            FeedAutoProfileFinish(ofa_capable_d3d11);
+        }
+        return;
+    }
+}
+
+// True when this frame should run the full NGX evaluate (half-rate duty support).
+static bool FeedAutoProfileShouldEvaluate(UINT64 frames_done)
+{
+    const int stride = g_feed_auto.evaluate_stride > 0 ? g_feed_auto.evaluate_stride : 1;
+    if (stride <= 1) return true;
+    // Always evaluate on reset / first frames so history does not go stale forever.
+    if (g_feed_adapt.want_reset || g_cfg.reset_mode == FeedReset_Every) return true;
+    if (frames_done < 30) return true;
+    return (frames_done % (UINT64)stride) == 0;
+}

--- a/src/feed_diag.h
+++ b/src/feed_diag.h
@@ -1,0 +1,91 @@
+// feed_diag.h -- extended diagnostics for ME / ghosting / adapt tests.
+// Dump-friendly lines tagged [diag] so a user can paste dlss5-feed.log back.
+//
+// Include AFTER feed_lightstab.h, feed_quality.h / g_cfg / g_feed_* are available.
+
+#pragma once
+
+struct FeedDiagCfg
+{
+    int  enabled;     // log_detail=1
+    int  every_n;     // periodic dump interval in delivered frames (default 60)
+};
+
+static FeedDiagCfg g_feed_diag_cfg = { 1, 60 };
+
+static void FeedDiagDump(const char *why, int reset_flag, UINT64 frame_n,
+                         bool mask_ok, UINT bb_w, UINT bb_h, UINT work_w, UINT work_h)
+{
+    if (g_feed_diag_cfg.enabled == 0) return;
+
+    const char *mv = "lumenite/reshade";
+    if (g_feed_velocity.bound_ok) mv = "engine_velocity";
+    else if (g_feed_ofa_cfg.enabled && FeedOfaReady()) mv = "ofa";
+    else if (g_feed_ofa_cfg.enabled) mv = "ofa_pending";
+
+    Log("[diag] ---- dump (%s) frame=%llu ----", why ? why : "?", frame_n);
+#if defined(_M_X64) || defined(__x86_64__)
+    Log("[diag] arch=x64 (in-process NGX). 32-bit games: use host64 helper — no in-process DLSS5 in a 32-bit PE.");
+#else
+    Log("[diag] arch=x86 — NGX cannot run here; host64 bridge is required.");
+#endif
+    Log("[diag] reset_mode=%d reset_every=%d InReset=%d",
+        g_feed_adapt_cfg.reset_mode, g_cfg.reset_every, reset_flag);
+    Log("[diag] adapt: %s | mask=%.4f lumaΔ=%.4f thr_mask=%.3f/%.3f thr_luma=%.3f rate=%.2f sampled=%d",
+        g_feed_adapt.status[0] ? g_feed_adapt.status : "-",
+        g_feed_adapt.mask_avg, g_feed_adapt.luma_delta,
+        g_feed_adapt_cfg.mask_thr, g_feed_adapt_cfg.mask_thr_vel, g_feed_adapt_cfg.luma_thr,
+        g_feed_adapt.reset_rate, g_feed_adapt.sampled_ok ? 1 : 0);
+    Log("[diag] mv_source=%s vel_en=%d bound=%d cands=%d chosen=%d cand_cfg=%d decode=%d scale=%.2f",
+        mv,
+        g_feed_velocity_cfg.enabled,
+        g_feed_velocity.bound_ok ? 1 : 0,
+        g_feed_velocity.cand_count,
+        g_feed_velocity.chosen_cand,
+        g_feed_velocity_cfg.cand,
+        g_feed_velocity_cfg.decode,
+        g_feed_velocity_cfg.scale);
+    if (g_feed_velocity.bound_ok)
+        Log("[diag] vel_bound: src=%s name=\"%s\" %dx%d",
+            g_feed_velocity.bound_src,
+            g_feed_velocity.name[0] ? g_feed_velocity.name : "?",
+            g_feed_velocity.last_w, g_feed_velocity.last_h);
+    if (g_feed_velocity.cand_count > 0)
+    {
+        const int nshow = g_feed_velocity.cand_count < 8 ? g_feed_velocity.cand_count : 8;
+        for (int i = 0; i < nshow; ++i)
+        {
+            const FeedVelocityCand &c = g_feed_velocity.cands[i];
+            Log("[diag] cand#%d %s %ux%u score=%d draws=%d depth=%d name=\"%s\"",
+                i, FeedVelocityFmtLabel(c.fmt), c.width, c.height, c.score,
+                c.draws_total, c.saw_with_depth ? 1 : 0,
+                c.name[0] ? c.name : "?");
+        }
+    }
+    Log("[diag] ofa_en=%d ofa_ready=%d grid=%d perf=%d | work=%d%% upscale=%d sharp=%.2f preset=%d mask_ok=%d",
+        g_feed_ofa_cfg.enabled, FeedOfaReady() ? 1 : 0, g_feed_ofa_cfg.grid, g_feed_ofa_cfg.perf,
+        g_cfg.work_resolution, g_cfg.work_upscale, g_cfg.work_sharpness, g_cfg.preset,
+        mask_ok ? 1 : 0);
+    Log("[diag] quality=%s custom=%d auto=%s applied=%d | bb=%ux%u work_tex=%ux%u lightstab=%d str=%.2f",
+        g_feed_quality_customized ? "custom" : FeedQualityCfgName(g_feed_quality),
+        g_feed_quality_customized ? 1 : 0,
+        g_feed_auto.name[0] ? g_feed_auto.name : "-",
+        g_feed_auto.applied,
+        bb_w, bb_h, work_w, work_h,
+        g_feed_lightstab_cfg.enabled, g_feed_lightstab_cfg.strength);
+    if (g_feed_lightstab.status[0])
+        Log("[diag] %s", g_feed_lightstab.status);
+}
+
+static void FeedDiagOnFrame(UINT64 n, int reset_flag,
+                            bool mask_ok, UINT bb_w, UINT bb_h, UINT work_w, UINT work_h)
+{
+    if (g_feed_diag_cfg.enabled == 0) return;
+    const int every = g_feed_diag_cfg.every_n > 0 ? g_feed_diag_cfg.every_n : 60;
+    static int prev_reset = 0;
+    const bool reset_edge = reset_flag != 0 && prev_reset == 0;
+    prev_reset = reset_flag;
+    if (n <= (UINT64)g_cfg.log_frames || (n % (UINT64)every) == 0 || reset_edge)
+        FeedDiagDump(reset_edge ? "reset_edge" : "periodic", reset_flag, n,
+                     mask_ok, bb_w, bb_h, work_w, work_h);
+}

--- a/src/feed_early_color.h
+++ b/src/feed_early_color.h
@@ -1,0 +1,702 @@
+// feed_early_color.h -- D3D11 SceneColor / HDR RT hunter + mid-frame snapshot for SLOT_COLOR.
+//
+// Include from dlss5-feed.cpp AFTER Log() is defined and <reshade.hpp> is available.
+// Off by default (early_color=0). When enabled and a fresh snap exists, FeedFrame11 can
+// feed NR from the snap instead of the Present backbuffer; otherwise Present fallback.
+// MVP composite: existing BlitOutputToBackbuffer after NR (HUD may be missing — honest).
+
+#pragma once
+
+#include <cstring>
+#include <cctype>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <d3d11.h>
+
+struct FeedEarlyColorCfg
+{
+    int enabled; // early_color= 0|1
+    int cand;    // early_color_cand= -1 auto | N
+};
+
+static FeedEarlyColorCfg g_feed_early_color_cfg = { 0, -1 };
+
+enum { kFeedEarlyMaxCands = 32 };
+
+struct FeedEarlyColorCand
+{
+    uint64_t handle;
+    uint32_t width, height;
+    reshade::api::format fmt;
+    char     name[96];
+    bool     name_hit;
+    int      score;
+    int      draws_frame;
+    int      draws_total;
+    bool     saw_with_depth;
+};
+
+struct FeedEarlyColorState
+{
+    FeedEarlyColorCand cands[kFeedEarlyMaxCands];
+    int cand_count;
+    int chosen_cand;
+
+    uint64_t bound_rt[8];
+    uint32_t bound_rt_count;
+    bool     bound_has_dsv;
+
+    UINT bb_w, bb_h;
+    uint64_t frame_id;
+    uint64_t snap_frame_id; // frame when snap was last filled
+    bool     snap_valid;
+    bool     using_early;   // last FeedFrame11 used snap
+    char     overlay_line[256];
+    char     status_line[96]; // "early" | "fallback Present"
+
+    // Private snap (native cand format, full-res)
+    ID3D11Texture2D *snap_tex;
+    DXGI_FORMAT snap_fmt;
+    UINT snap_w, snap_h;
+
+    // Converted to backbuffer/work format for CopyOrResampleInputs
+    ID3D11Texture2D *out_tex;
+    DXGI_FORMAT out_fmt;
+    UINT out_w, out_h;
+
+    ID3D11VertexShader *blit_vs;
+    ID3D11PixelShader  *blit_ps;
+    ID3D11SamplerState *blit_smp;
+    bool blit_ready;
+
+    // Previous bind set — snapshot when a high-score cand leaves the RT set
+    uint64_t prev_bound[8];
+    uint32_t prev_bound_count;
+};
+
+static FeedEarlyColorState g_feed_early_color = {};
+struct FeedEarlyColorInitOnce {
+    FeedEarlyColorInitOnce()
+    {
+        g_feed_early_color.chosen_cand = -1;
+        g_feed_early_color_cfg.cand = -1;
+        _snprintf_s(g_feed_early_color.status_line, sizeof(g_feed_early_color.status_line),
+                    _TRUNCATE, "fallback Present");
+    }
+};
+static FeedEarlyColorInitOnce g_feed_early_color_init_once;
+
+static const GUID kFeedEarlyDebugNameGuid =
+    { 0x429b8c22, 0x9188, 0x4b0c, { 0x87, 0x42, 0xac, 0xb0, 0xbf, 0x85, 0xc2, 0x00 } };
+
+static bool FeedEarlyColorNameHit(const char *name)
+{
+    if (name == nullptr || name[0] == '\0') return false;
+    char lower[256];
+    size_t n = 0;
+    for (; name[n] != '\0' && n + 1 < sizeof(lower); ++n)
+        lower[n] = static_cast<char>(tolower(static_cast<unsigned char>(name[n])));
+    lower[n] = '\0';
+    if (strstr(lower, "dlss5") != nullptr) return false;
+    if (strstr(lower, "lumenite") != nullptr) return false;
+    if (strstr(lower, "velocity") != nullptr) return false;
+    if (strstr(lower, "motion") != nullptr && strstr(lower, "vector") != nullptr) return false;
+    return strstr(lower, "scenecolor") != nullptr ||
+           strstr(lower, "scene_color") != nullptr ||
+           strstr(lower, "scene colour") != nullptr ||
+           strstr(lower, "hdrcolor") != nullptr ||
+           strstr(lower, "hdr_color") != nullptr ||
+           strstr(lower, "hdr") != nullptr ||
+           strstr(lower, "lighting") != nullptr ||
+           strstr(lower, "lightaccumulation") != nullptr ||
+           strstr(lower, "diffuse") != nullptr ||
+           (strstr(lower, "color") != nullptr && strstr(lower, "gbuffer") == nullptr) ||
+           (strstr(lower, "colour") != nullptr && strstr(lower, "gbuffer") == nullptr);
+}
+
+static bool FeedEarlyColorFmtCandidate(reshade::api::format f)
+{
+    using reshade::api::format;
+    return f == format::r16g16b16a16_float ||
+           f == format::r16g16b16a16_typeless ||
+           f == format::r11g11b10_float ||
+           f == format::r32g32b32a32_float ||
+           f == format::r10g10b10a2_unorm ||
+           f == format::r8g8b8a8_unorm ||
+           f == format::r8g8b8a8_unorm_srgb ||
+           f == format::b8g8r8a8_unorm ||
+           f == format::b8g8r8a8_unorm_srgb;
+}
+
+static const char *FeedEarlyColorFmtLabel(reshade::api::format f)
+{
+    using reshade::api::format;
+    switch (f)
+    {
+    case format::r16g16b16a16_float:
+    case format::r16g16b16a16_typeless: return "RGBA16F";
+    case format::r11g11b10_float: return "R11G11B10";
+    case format::r32g32b32a32_float: return "RGBA32F";
+    case format::r10g10b10a2_unorm: return "RGB10A2";
+    case format::r8g8b8a8_unorm:
+    case format::r8g8b8a8_unorm_srgb: return "RGBA8";
+    case format::b8g8r8a8_unorm:
+    case format::b8g8r8a8_unorm_srgb: return "BGRA8";
+    default: return "?";
+    }
+}
+
+static bool FeedEarlyColorFmtIsHdr(reshade::api::format f)
+{
+    using reshade::api::format;
+    return f == format::r16g16b16a16_float || f == format::r16g16b16a16_typeless ||
+           f == format::r11g11b10_float || f == format::r32g32b32a32_float;
+}
+
+static DXGI_FORMAT FeedEarlyColorDxgiTyped(reshade::api::format f)
+{
+    using reshade::api::format;
+    switch (f)
+    {
+    case format::r16g16b16a16_float:
+    case format::r16g16b16a16_typeless: return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    case format::r11g11b10_float: return DXGI_FORMAT_R11G11B10_FLOAT;
+    case format::r32g32b32a32_float: return DXGI_FORMAT_R32G32B32A32_FLOAT;
+    case format::r10g10b10a2_unorm: return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case format::r8g8b8a8_unorm: return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case format::r8g8b8a8_unorm_srgb: return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    case format::b8g8r8a8_unorm: return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case format::b8g8r8a8_unorm_srgb: return DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+    default: return DXGI_FORMAT_UNKNOWN;
+    }
+}
+
+static void FeedEarlyColorReadDebugName(ID3D11DeviceChild *obj, char *out, size_t out_n)
+{
+    out[0] = '\0';
+    if (obj == nullptr || out_n < 2) return;
+    UINT sz = 0;
+    if (FAILED(obj->GetPrivateData(kFeedEarlyDebugNameGuid, &sz, nullptr)) || sz == 0 || sz > 512)
+        return;
+    char buf[512];
+    if (sz > sizeof(buf)) sz = sizeof(buf);
+    if (FAILED(obj->GetPrivateData(kFeedEarlyDebugNameGuid, &sz, buf))) return;
+    if (sz > 0 && buf[sz - 1] == '\0')
+        _snprintf_s(out, out_n, _TRUNCATE, "%s", buf);
+    else
+    {
+        if (sz >= out_n) sz = (UINT)(out_n - 1);
+        memcpy(out, buf, sz);
+        out[sz] = '\0';
+    }
+}
+
+static void FeedEarlyColorReleaseBlit()
+{
+    if (g_feed_early_color.blit_vs) { g_feed_early_color.blit_vs->Release(); g_feed_early_color.blit_vs = nullptr; }
+    if (g_feed_early_color.blit_ps) { g_feed_early_color.blit_ps->Release(); g_feed_early_color.blit_ps = nullptr; }
+    if (g_feed_early_color.blit_smp) { g_feed_early_color.blit_smp->Release(); g_feed_early_color.blit_smp = nullptr; }
+    g_feed_early_color.blit_ready = false;
+}
+
+static void FeedEarlyColorReleaseSnap()
+{
+    if (g_feed_early_color.snap_tex) { g_feed_early_color.snap_tex->Release(); g_feed_early_color.snap_tex = nullptr; }
+    g_feed_early_color.snap_w = g_feed_early_color.snap_h = 0;
+    g_feed_early_color.snap_fmt = DXGI_FORMAT_UNKNOWN;
+    g_feed_early_color.snap_valid = false;
+}
+
+static void FeedEarlyColorReleaseOut()
+{
+    if (g_feed_early_color.out_tex) { g_feed_early_color.out_tex->Release(); g_feed_early_color.out_tex = nullptr; }
+    g_feed_early_color.out_w = g_feed_early_color.out_h = 0;
+    g_feed_early_color.out_fmt = DXGI_FORMAT_UNKNOWN;
+}
+
+static bool FeedEarlyColorEnsureBlit(ID3D11Device *dev)
+{
+    if (g_feed_early_color.blit_ready) return true;
+    if (dev == nullptr) return false;
+
+    typedef HRESULT (WINAPI *pD3DCompile)(LPCVOID, SIZE_T, LPCSTR, const D3D_SHADER_MACRO *,
+                                          ID3DInclude *, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob **, ID3DBlob **);
+    HMODULE m = LoadLibraryW(L"d3dcompiler_47.dll");
+    auto compile = m != nullptr ? reinterpret_cast<pD3DCompile>(GetProcAddress(m, "D3DCompile")) : nullptr;
+    if (compile == nullptr) { Log("[feed] early_color blit: d3dcompiler_47.dll unavailable"); return false; }
+
+    static const char kSrc[] =
+        "Texture2D src_tex : register(t0);\n"
+        "SamplerState smp : register(s0);\n"
+        "struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };\n"
+        "VSOut vs(uint id : SV_VertexID) { VSOut o; float2 uv = float2((id << 1) & 2, id & 2);\n"
+        "  o.uv = uv; o.pos = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1); return o; }\n"
+        "float4 ps(VSOut i) : SV_Target { return src_tex.SampleLevel(smp, i.uv, 0); }\n";
+
+    ID3DBlob *vs = nullptr, *ps = nullptr, *err = nullptr;
+    HRESULT hr = compile(kSrc, sizeof(kSrc) - 1, "earlyblit", nullptr, nullptr, "vs", "vs_5_0", 0, 0, &vs, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] early_color blit VS failed 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        return false;
+    }
+    if (err) { err->Release(); err = nullptr; }
+    hr = compile(kSrc, sizeof(kSrc) - 1, "earlyblit", nullptr, nullptr, "ps", "ps_5_0", 0, 0, &ps, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] early_color blit PS failed 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        if (vs) vs->Release();
+        return false;
+    }
+    if (err) err->Release();
+
+    hr = dev->CreateVertexShader(vs->GetBufferPointer(), vs->GetBufferSize(), nullptr, &g_feed_early_color.blit_vs);
+    if (SUCCEEDED(hr))
+        hr = dev->CreatePixelShader(ps->GetBufferPointer(), ps->GetBufferSize(), nullptr, &g_feed_early_color.blit_ps);
+    vs->Release();
+    ps->Release();
+    if (FAILED(hr)) { Log("[feed] early_color blit shader create failed 0x%08X", hr); FeedEarlyColorReleaseBlit(); return false; }
+
+    D3D11_SAMPLER_DESC sd = {};
+    sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+    sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    if (FAILED(dev->CreateSamplerState(&sd, &g_feed_early_color.blit_smp)))
+    { FeedEarlyColorReleaseBlit(); return false; }
+
+    g_feed_early_color.blit_ready = true;
+    Log("[feed] early_color blit shaders ready");
+    return true;
+}
+
+static bool FeedEarlyColorEnsureSnap(ID3D11Device *dev, UINT w, UINT h, DXGI_FORMAT fmt)
+{
+    if (g_feed_early_color.snap_tex && g_feed_early_color.snap_w == w &&
+        g_feed_early_color.snap_h == h && g_feed_early_color.snap_fmt == fmt)
+        return true;
+    FeedEarlyColorReleaseSnap();
+    D3D11_TEXTURE2D_DESC d = {};
+    d.Width = w; d.Height = h; d.MipLevels = 1; d.ArraySize = 1;
+    d.Format = fmt;
+    d.SampleDesc.Count = 1;
+    d.Usage = D3D11_USAGE_DEFAULT;
+    d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_early_color.snap_tex)) || !g_feed_early_color.snap_tex)
+        return false;
+    g_feed_early_color.snap_w = w;
+    g_feed_early_color.snap_h = h;
+    g_feed_early_color.snap_fmt = fmt;
+    return true;
+}
+
+static bool FeedEarlyColorEnsureOut(ID3D11Device *dev, UINT w, UINT h, DXGI_FORMAT fmt)
+{
+    if (g_feed_early_color.out_tex && g_feed_early_color.out_w == w &&
+        g_feed_early_color.out_h == h && g_feed_early_color.out_fmt == fmt)
+        return true;
+    FeedEarlyColorReleaseOut();
+    D3D11_TEXTURE2D_DESC d = {};
+    d.Width = w; d.Height = h; d.MipLevels = 1; d.ArraySize = 1;
+    d.Format = fmt;
+    d.SampleDesc.Count = 1;
+    d.Usage = D3D11_USAGE_DEFAULT;
+    d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_early_color.out_tex)) || !g_feed_early_color.out_tex)
+        return false;
+    g_feed_early_color.out_w = w;
+    g_feed_early_color.out_h = h;
+    g_feed_early_color.out_fmt = fmt;
+    return true;
+}
+
+static bool FeedEarlyColorBlitTo(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                                 ID3D11Texture2D *src, DXGI_FORMAT srv_fmt,
+                                 ID3D11Texture2D *dst, UINT dst_w, UINT dst_h)
+{
+    if (!FeedEarlyColorEnsureBlit(dev) || src == nullptr || dst == nullptr) return false;
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC sv = {};
+    sv.Format = srv_fmt;
+    sv.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    sv.Texture2D.MipLevels = 1;
+    ID3D11ShaderResourceView *srv = nullptr;
+    if (FAILED(dev->CreateShaderResourceView(src, &sv, &srv)) || !srv)
+        return false;
+
+    ID3D11RenderTargetView *rtv = nullptr;
+    if (FAILED(dev->CreateRenderTargetView(dst, nullptr, &rtv)) || !rtv)
+    {
+        srv->Release();
+        return false;
+    }
+
+    ID3D11RenderTargetView *prev_rtv = nullptr;
+    ID3D11DepthStencilView *prev_dsv = nullptr;
+    ctx->OMGetRenderTargets(1, &prev_rtv, &prev_dsv);
+
+    D3D11_VIEWPORT vp = {};
+    vp.Width = (float)dst_w;
+    vp.Height = (float)dst_h;
+    vp.MaxDepth = 1.0f;
+    ctx->RSSetViewports(1, &vp);
+    ctx->OMSetRenderTargets(1, &rtv, nullptr);
+    ctx->IASetInputLayout(nullptr);
+    ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ctx->VSSetShader(g_feed_early_color.blit_vs, nullptr, 0);
+    ctx->PSSetShader(g_feed_early_color.blit_ps, nullptr, 0);
+    ctx->PSSetShaderResources(0, 1, &srv);
+    ctx->PSSetSamplers(0, 1, &g_feed_early_color.blit_smp);
+    ctx->Draw(3, 0);
+
+    ID3D11ShaderResourceView *null_srv = nullptr;
+    ctx->PSSetShaderResources(0, 1, &null_srv);
+    ctx->OMSetRenderTargets(1, &prev_rtv, prev_dsv);
+    if (prev_rtv) prev_rtv->Release();
+    if (prev_dsv) prev_dsv->Release();
+    rtv->Release();
+    srv->Release();
+    return true;
+}
+
+static int FeedEarlyColorFindCand(uint64_t handle)
+{
+    for (int i = 0; i < g_feed_early_color.cand_count; ++i)
+        if (g_feed_early_color.cands[i].handle == handle) return i;
+    return -1;
+}
+
+static void FeedEarlyColorUpsert(reshade::api::device *device, reshade::api::resource res)
+{
+    if (device == nullptr || res.handle == 0) return;
+    const reshade::api::resource_desc desc = device->get_resource_desc(res);
+    if (desc.type != reshade::api::resource_type::texture_2d) return;
+    if (desc.texture.depth_or_layers != 1) return;
+    if (!FeedEarlyColorFmtCandidate(desc.texture.format)) return;
+    if (desc.texture.width < 128 || desc.texture.height < 128) return;
+    if (g_feed_early_color.bb_w != 0 && desc.texture.width * 2 < g_feed_early_color.bb_w) return;
+
+    char name[96] = {};
+    if (device->get_api() == reshade::api::device_api::d3d11)
+        FeedEarlyColorReadDebugName(reinterpret_cast<ID3D11DeviceChild *>(res.handle), name, sizeof(name));
+
+    const bool name_hit = FeedEarlyColorNameHit(name);
+    int idx = FeedEarlyColorFindCand(res.handle);
+    if (idx < 0)
+    {
+        if (g_feed_early_color.cand_count >= kFeedEarlyMaxCands)
+        {
+            int worst = 0;
+            for (int i = 1; i < g_feed_early_color.cand_count; ++i)
+                if (g_feed_early_color.cands[i].score < g_feed_early_color.cands[worst].score) worst = i;
+            if (g_feed_early_color.cands[worst].score > 20) return;
+            idx = worst;
+        }
+        else
+            idx = g_feed_early_color.cand_count++;
+        FeedEarlyColorCand &c = g_feed_early_color.cands[idx];
+        memset(&c, 0, sizeof(c));
+        c.handle = res.handle;
+        c.width = desc.texture.width;
+        c.height = desc.texture.height;
+        c.fmt = desc.texture.format;
+        if (name[0]) _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "%s", name);
+        else _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "RT %s %ux%u",
+                         FeedEarlyColorFmtLabel(c.fmt), c.width, c.height);
+        c.name_hit = name_hit;
+    }
+    else
+    {
+        FeedEarlyColorCand &c = g_feed_early_color.cands[idx];
+        c.width = desc.texture.width;
+        c.height = desc.texture.height;
+        c.fmt = desc.texture.format;
+        if (name_hit) { c.name_hit = true; if (name[0]) _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "%s", name); }
+    }
+}
+
+static void FeedEarlyColorRescore(FeedEarlyColorCand &c)
+{
+    int s = 0;
+    if (c.name_hit) s += 200;
+    if (FeedEarlyColorFmtIsHdr(c.fmt)) s += 100;
+    else if (c.fmt == reshade::api::format::r10g10b10a2_unorm) s += 40;
+    else s += 15;
+
+    if (g_feed_early_color.bb_w != 0 && c.width == g_feed_early_color.bb_w && c.height == g_feed_early_color.bb_h)
+        s += 120;
+    else if (g_feed_early_color.bb_w != 0 && c.width >= g_feed_early_color.bb_w * 3 / 4)
+        s += 40;
+
+    s += c.draws_frame > 40 ? 40 : c.draws_frame;
+    if (c.saw_with_depth) s += 25;
+    // Prefer SceneColor-like names over bare "Color" UI targets with few draws.
+    if (!c.name_hit && c.draws_total < 20) s -= 30;
+    if (s < 0) s = 0;
+    c.score = s;
+}
+
+static void FeedEarlyColorBeginFrame(UINT bb_w, UINT bb_h)
+{
+    g_feed_early_color.bb_w = bb_w;
+    g_feed_early_color.bb_h = bb_h;
+    ++g_feed_early_color.frame_id;
+    g_feed_early_color.using_early = false;
+}
+
+static void FeedEarlyColorAfterAcquire()
+{
+    for (int i = 0; i < g_feed_early_color.cand_count; ++i)
+        g_feed_early_color.cands[i].draws_frame = 0;
+}
+
+static int FeedEarlyColorAutoPick(UINT expect_w, UINT expect_h)
+{
+    int best = -1, best_score = -1;
+    for (int i = 0; i < g_feed_early_color.cand_count; ++i)
+    {
+        FeedEarlyColorCand &c = g_feed_early_color.cands[i];
+        FeedEarlyColorRescore(c);
+        const bool full = (c.width == expect_w && c.height == expect_h);
+        const bool near_full = (c.width * 4 >= expect_w * 3 && c.height * 4 >= expect_h * 3);
+        if (!full && !near_full && !c.name_hit) continue;
+        if (!FeedEarlyColorFmtIsHdr(c.fmt) && !c.name_hit && c.draws_total < 30) continue;
+        if (c.score > best_score) { best_score = c.score; best = i; }
+    }
+    return best;
+}
+
+static void FeedEarlyColorUpdateOverlay()
+{
+    if (g_feed_early_color.chosen_cand >= 0 &&
+        g_feed_early_color.chosen_cand < g_feed_early_color.cand_count)
+    {
+        const FeedEarlyColorCand &c = g_feed_early_color.cands[g_feed_early_color.chosen_cand];
+        _snprintf_s(g_feed_early_color.overlay_line, sizeof(g_feed_early_color.overlay_line), _TRUNCATE,
+                    "pick #%d %s %ux%u score=%d %s | %s",
+                    g_feed_early_color.chosen_cand, FeedEarlyColorFmtLabel(c.fmt),
+                    c.width, c.height, c.score, c.name,
+                    g_feed_early_color.snap_valid ? "snap fresh" : "snap stale");
+    }
+    else
+        _snprintf_s(g_feed_early_color.overlay_line, sizeof(g_feed_early_color.overlay_line), _TRUNCATE,
+                    "%d color RT candidate(s) — early_color off or no pick",
+                    g_feed_early_color.cand_count);
+}
+
+static bool FeedEarlyColorSnapshotHandle(ID3D11Device *dev, ID3D11DeviceContext *ctx, uint64_t handle)
+{
+    if (dev == nullptr || ctx == nullptr || handle == 0) return false;
+    auto *raw = reinterpret_cast<ID3D11Resource *>(handle);
+    ID3D11Texture2D *src = nullptr;
+    if (FAILED(raw->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(&src))) || !src)
+        return false;
+    D3D11_TEXTURE2D_DESC sd = {};
+    src->GetDesc(&sd);
+    if (sd.SampleDesc.Count != 1)
+    {
+        src->Release();
+        return false;
+    }
+    DXGI_FORMAT typed = sd.Format;
+    // Typeless → typed for create/copy; prefer FLOAT HDR layouts.
+    if (typed == DXGI_FORMAT_R16G16B16A16_TYPELESS) typed = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    if (!FeedEarlyColorEnsureSnap(dev, sd.Width, sd.Height, typed))
+    {
+        src->Release();
+        return false;
+    }
+    ctx->CopyResource(g_feed_early_color.snap_tex, src);
+    src->Release();
+    g_feed_early_color.snap_frame_id = g_feed_early_color.frame_id;
+    g_feed_early_color.snap_valid = true;
+    return true;
+}
+
+static void FeedEarlyColorTrySnapshotLeaving(ID3D11Device *dev, ID3D11DeviceContext *ctx)
+{
+    if (g_feed_early_color_cfg.enabled == 0 || dev == nullptr || ctx == nullptr) return;
+    int pick = g_feed_early_color_cfg.cand;
+    if (pick < 0 || pick >= g_feed_early_color.cand_count)
+        pick = FeedEarlyColorAutoPick(g_feed_early_color.bb_w, g_feed_early_color.bb_h);
+    if (pick < 0 || pick >= g_feed_early_color.cand_count) return;
+    g_feed_early_color.chosen_cand = pick;
+    const uint64_t want = g_feed_early_color.cands[pick].handle;
+
+    bool was = false, now = false;
+    for (uint32_t i = 0; i < g_feed_early_color.prev_bound_count; ++i)
+        if (g_feed_early_color.prev_bound[i] == want) was = true;
+    for (uint32_t i = 0; i < g_feed_early_color.bound_rt_count; ++i)
+        if (g_feed_early_color.bound_rt[i] == want) now = true;
+
+    // Snapshot when the chosen SceneColor leaves the RT set (end of lighting / before post).
+    if (was && !now)
+        FeedEarlyColorSnapshotHandle(dev, ctx, want);
+}
+
+static void FeedEarlyColorOnBindRTs(reshade::api::command_list *cmd_list, uint32_t count,
+                                   const reshade::api::resource_view *rtvs, reshade::api::resource_view dsv)
+{
+    // Always remember previous binds when enabled so we can snap on unbind.
+    memcpy(g_feed_early_color.prev_bound, g_feed_early_color.bound_rt,
+           sizeof(uint64_t) * g_feed_early_color.bound_rt_count);
+    g_feed_early_color.prev_bound_count = g_feed_early_color.bound_rt_count;
+
+    g_feed_early_color.bound_rt_count = 0;
+    g_feed_early_color.bound_has_dsv = dsv.handle != 0;
+    if (cmd_list == nullptr || g_feed_early_color_cfg.enabled == 0) return;
+    reshade::api::device *dev = cmd_list->get_device();
+    if (dev == nullptr || dev->get_api() != reshade::api::device_api::d3d11) return;
+
+    const uint32_t n = count > 8 ? 8 : count;
+    for (uint32_t i = 0; i < n; ++i)
+    {
+        if (rtvs[i].handle == 0) continue;
+        const reshade::api::resource res = dev->get_resource_from_view(rtvs[i]);
+        if (res.handle == 0) continue;
+        g_feed_early_color.bound_rt[g_feed_early_color.bound_rt_count++] = res.handle;
+        FeedEarlyColorUpsert(dev, res);
+    }
+
+    auto *ctx = reinterpret_cast<ID3D11DeviceContext *>(cmd_list->get_native());
+    if (ctx != nullptr)
+    {
+        ID3D11Device *dev11 = nullptr;
+        ctx->GetDevice(&dev11);
+        if (dev11 != nullptr)
+        {
+            FeedEarlyColorTrySnapshotLeaving(dev11, ctx);
+            dev11->Release();
+        }
+    }
+}
+
+static bool FeedEarlyColorOnDraw(reshade::api::command_list *cmd_list)
+{
+    if (g_feed_early_color_cfg.enabled == 0 || g_feed_early_color.bound_rt_count == 0) return false;
+    if (cmd_list == nullptr) return false;
+    reshade::api::device *dev = cmd_list->get_device();
+    if (dev == nullptr || dev->get_api() != reshade::api::device_api::d3d11) return false;
+    for (uint32_t i = 0; i < g_feed_early_color.bound_rt_count; ++i)
+    {
+        reshade::api::resource res = { g_feed_early_color.bound_rt[i] };
+        FeedEarlyColorUpsert(dev, res);
+        const int idx = FeedEarlyColorFindCand(res.handle);
+        if (idx < 0) continue;
+        FeedEarlyColorCand &c = g_feed_early_color.cands[idx];
+        ++c.draws_frame;
+        ++c.draws_total;
+        if (g_feed_early_color.bound_has_dsv) c.saw_with_depth = true;
+        FeedEarlyColorRescore(c);
+    }
+    return false;
+}
+
+static void FeedEarlyColorOnInitResource(reshade::api::device *device,
+                                         const reshade::api::resource_desc &desc,
+                                         reshade::api::resource resource)
+{
+    if (device == nullptr || resource.handle == 0) return;
+    if (device->get_api() != reshade::api::device_api::d3d11) return;
+    if (desc.type != reshade::api::resource_type::texture_2d) return;
+    if (!FeedEarlyColorFmtCandidate(desc.texture.format)) return;
+    FeedEarlyColorUpsert(device, resource);
+    const int idx = FeedEarlyColorFindCand(resource.handle);
+    if (idx >= 0) FeedEarlyColorRescore(g_feed_early_color.cands[idx]);
+}
+
+static void FeedEarlyColorOnDestroyResource(reshade::api::resource resource)
+{
+    if (resource.handle == 0) return;
+    for (int i = 0; i < g_feed_early_color.cand_count; ++i)
+    {
+        if (g_feed_early_color.cands[i].handle != resource.handle) continue;
+        g_feed_early_color.cands[i] = g_feed_early_color.cands[g_feed_early_color.cand_count - 1];
+        --g_feed_early_color.cand_count;
+        if (g_feed_early_color.chosen_cand == i) g_feed_early_color.chosen_cand = -1;
+        else if (g_feed_early_color.chosen_cand == g_feed_early_color.cand_count)
+            g_feed_early_color.chosen_cand = i;
+        g_feed_early_color.snap_valid = false;
+        return;
+    }
+}
+
+static void FeedEarlyColorClearCands()
+{
+    g_feed_early_color.cand_count = 0;
+    g_feed_early_color.chosen_cand = -1;
+    g_feed_early_color.snap_valid = false;
+    g_feed_early_color.overlay_line[0] = '\0';
+    Log("[feed] early_color: candidate list cleared (rescan)");
+}
+
+static bool FeedEarlyColorSnapFresh()
+{
+    if (!g_feed_early_color.snap_valid || g_feed_early_color.snap_tex == nullptr)
+        return false;
+    // Accept snap from this frame or the immediately previous hunt frame.
+    const uint64_t age = g_feed_early_color.frame_id - g_feed_early_color.snap_frame_id;
+    return age <= 1;
+}
+
+// Returns AddRef'd texture in want_fmt / expect size for SLOT_COLOR, or nullptr → Present.
+static ID3D11Texture2D *FeedEarlyColorAcquire(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                                              UINT expect_w, UINT expect_h, DXGI_FORMAT want_fmt)
+{
+    g_feed_early_color.using_early = false;
+    _snprintf_s(g_feed_early_color.status_line, sizeof(g_feed_early_color.status_line),
+                _TRUNCATE, "fallback Present");
+    if (g_feed_early_color_cfg.enabled == 0 || dev == nullptr || ctx == nullptr)
+    {
+        FeedEarlyColorUpdateOverlay();
+        return nullptr;
+    }
+
+    if (g_feed_early_color_cfg.cand >= 0 && g_feed_early_color_cfg.cand < g_feed_early_color.cand_count)
+        g_feed_early_color.chosen_cand = g_feed_early_color_cfg.cand;
+    else if (g_feed_early_color.chosen_cand < 0)
+        g_feed_early_color.chosen_cand = FeedEarlyColorAutoPick(expect_w, expect_h);
+
+    // Last-chance snap if still bound at Present (some engines keep SceneColor live).
+    if (!FeedEarlyColorSnapFresh() && g_feed_early_color.chosen_cand >= 0 &&
+        g_feed_early_color.chosen_cand < g_feed_early_color.cand_count)
+    {
+        FeedEarlyColorSnapshotHandle(dev, ctx, g_feed_early_color.cands[g_feed_early_color.chosen_cand].handle);
+    }
+
+    FeedEarlyColorUpdateOverlay();
+    if (!FeedEarlyColorSnapFresh()) return nullptr;
+
+    if (!FeedEarlyColorEnsureOut(dev, expect_w, expect_h, want_fmt))
+        return nullptr;
+
+    const bool same =
+        g_feed_early_color.snap_w == expect_w && g_feed_early_color.snap_h == expect_h &&
+        g_feed_early_color.snap_fmt == want_fmt;
+    if (same)
+        ctx->CopyResource(g_feed_early_color.out_tex, g_feed_early_color.snap_tex);
+    else if (!FeedEarlyColorBlitTo(dev, ctx, g_feed_early_color.snap_tex, g_feed_early_color.snap_fmt,
+                                   g_feed_early_color.out_tex, expect_w, expect_h))
+        return nullptr;
+
+    g_feed_early_color.using_early = true;
+    _snprintf_s(g_feed_early_color.status_line, sizeof(g_feed_early_color.status_line),
+                _TRUNCATE, "early");
+    static bool said = false;
+    if (!said)
+    {
+        said = true;
+        Log("[feed] early_color: feeding SLOT_COLOR from SceneColor snap (%ux%u %s → %s) — "
+            "NR output still blits over backbuffer (HUD may be missing)",
+            g_feed_early_color.snap_w, g_feed_early_color.snap_h,
+            FeedEarlyColorFmtLabel(g_feed_early_color.cands[
+                g_feed_early_color.chosen_cand >= 0 ? g_feed_early_color.chosen_cand : 0].fmt),
+            "BB");
+    }
+    g_feed_early_color.out_tex->AddRef();
+    return g_feed_early_color.out_tex;
+}

--- a/src/feed_hud.h
+++ b/src/feed_hud.h
@@ -1,0 +1,147 @@
+// feed_hud.h -- lightweight in-game ImGui stats panel (no PresentMon).
+//
+// Include near TimingTick / DrawOverlay. Hotkey key_hud (default F9) toggles hud_stats.
+// Cfg lives in feed_async.h (early). Register overlay title "DLSS 5 Feed · HUD".
+
+#pragma once
+
+enum { kFeedHudSpark = 64 };
+
+struct FeedHudState
+{
+    float fps_ring[kFeedHudSpark];
+    int   fps_i;
+    int   fps_n;
+    float last_fps;
+    float last_frame_ms;
+    float last_cpu_pct;
+    float last_gpu_ms;
+    float last_eval_ms;
+    int sample_countdown;
+};
+
+static FeedHudState g_feed_hud = {};
+
+static void FeedHudPushFps(float fps)
+{
+    if (fps < 1.f || fps > 1000.f)
+        return;
+    g_feed_hud.fps_ring[g_feed_hud.fps_i % kFeedHudSpark] = fps;
+    g_feed_hud.fps_i = (g_feed_hud.fps_i + 1) % kFeedHudSpark;
+    if (g_feed_hud.fps_n < kFeedHudSpark)
+        ++g_feed_hud.fps_n;
+    g_feed_hud.last_fps = fps;
+}
+
+// Call from TimingTick when interval known. Samples cheaply unless HUD is visible.
+static void FeedHudOnInterval(double interval_ms)
+{
+    if (interval_ms < 1.0 || interval_ms > 250.0)
+        return;
+    g_feed_hud.last_frame_ms = (float)interval_ms;
+    const float fps = 1000.f / (float)interval_ms;
+    FeedHudPushFps(fps);
+
+    if (g_feed_hud_cfg.enabled == 0)
+        return;
+    if (++g_feed_hud.sample_countdown < 8)
+        return;
+    g_feed_hud.sample_countdown = 0;
+    const float cpu = FeedPerfCpuPercent();
+    if (cpu >= 0.f)
+        g_feed_hud.last_cpu_pct = cpu;
+    if (g.ts_n > 0)
+        g_feed_hud.last_gpu_ms = (float)(g.ts_sum_ms / (double)g.ts_n);
+    if (g.qpf > 0 && g_last_eval_ticks > 0)
+        g_feed_hud.last_eval_ms = (float)(1000.0 * (double)g_last_eval_ticks / (double)g.qpf);
+}
+
+static const char *FeedHudKeyName(int vk)
+{
+    switch (vk)
+    {
+    case 0x70: return "F1";  case 0x71: return "F2";  case 0x72: return "F3";
+    case 0x73: return "F4";  case 0x74: return "F5";  case 0x75: return "F6";
+    case 0x76: return "F7";  case 0x77: return "F8";  case 0x78: return "F9";
+    case 0x79: return "F10"; case 0x7A: return "F11"; case 0x7B: return "F12";
+    default: return "key";
+    }
+}
+
+static void FeedPollConfigHotkeys()
+{
+    static bool prev_async = false;
+    static bool prev_hud = false;
+    const bool async_down = (GetAsyncKeyState(g_feed_async_cfg.key) & 0x8000) != 0;
+    const bool hud_down = (GetAsyncKeyState(g_feed_hud_cfg.key) & 0x8000) != 0;
+    if (async_down && !prev_async)
+    {
+        g_feed_async_cfg.enabled = g_feed_async_cfg.enabled ? 0 : 1;
+        FeedAsyncUpdateLagMetric();
+        CfgSave();
+        Log("[feed] async_feed=%d (hotkey %s) — display lag %d frame(s)",
+            g_feed_async_cfg.enabled, FeedHudKeyName(g_feed_async_cfg.key),
+            g_display_lag_frames);
+        FeedPerfMarkDirty();
+    }
+    if (hud_down && !prev_hud)
+    {
+        g_feed_hud_cfg.enabled = g_feed_hud_cfg.enabled ? 0 : 1;
+        CfgSave();
+        Log("[feed] hud_stats=%d (hotkey %s)", g_feed_hud_cfg.enabled,
+            FeedHudKeyName(g_feed_hud_cfg.key));
+    }
+    prev_async = async_down;
+    prev_hud = hud_down;
+}
+
+static void DrawFeedHudPanel(reshade::api::effect_runtime * /*rt*/)
+{
+    if (g_feed_hud_cfg.enabled == 0)
+        return;
+
+    const ImGuiIO &io = ImGui::GetIO();
+    const float pad = 10.f;
+    ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - pad, pad), ImGuiCond_Always, ImVec2(1.f, 0.f));
+    ImGui::SetNextWindowBgAlpha(0.72f);
+    ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize |
+        ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
+    if (!ImGui::Begin("##dlss5_feed_hud", nullptr, flags))
+    {
+        ImGui::End();
+        return;
+    }
+
+    if (g_feed_async_cfg.enabled)
+        ImGui::TextColored(ImVec4(0.55f, 0.85f, 1.0f, 1.0f),
+                           "Async feed ON · display lag ~1 frame");
+    else
+        ImGui::TextDisabled("Async feed OFF · display lag 0");
+
+    ImGui::Separator();
+    ImGui::Text("FPS  %.1f", g_feed_hud.last_fps);
+    ImGui::Text("frame  %.2f ms", g_feed_hud.last_frame_ms);
+    ImGui::Text("CPU  %.0f%%", g_feed_hud.last_cpu_pct);
+    ImGui::Text("GPU feed  %.2f ms", g_feed_hud.last_gpu_ms);
+    ImGui::Text("NR (eval CPU)  %.2f ms", g_feed_hud.last_eval_ms);
+    ImGui::Text("async  %s", g_feed_async_cfg.enabled ? "on" : "off");
+    ImGui::Text("display_lag_frames  %d", g_display_lag_frames);
+    {
+        const int wr = g_cfg.work_resolution;
+        const int stride = g_feed_auto.evaluate_stride > 0 ? g_feed_auto.evaluate_stride : 1;
+        ImGui::Text("work %d%% · stride %d", wr, stride);
+    }
+
+    if (g_feed_hud.fps_n > 4)
+    {
+        ImGui::PlotLines("##fps_spark", g_feed_hud.fps_ring, g_feed_hud.fps_n,
+                         g_feed_hud.fps_i % kFeedHudSpark, nullptr, 0.f, 0.f, ImVec2(160.f, 28.f));
+    }
+
+    ImGui::TextDisabled("%s HUD · %s async",
+                        FeedHudKeyName(g_feed_hud_cfg.key),
+                        FeedHudKeyName(g_feed_async_cfg.key));
+    ImGui::End();
+}

--- a/src/feed_lightstab.h
+++ b/src/feed_lightstab.h
@@ -1,0 +1,261 @@
+// feed_lightstab.h -- post-DLSS low-frequency lighting flicker dampener.
+//
+// We cannot cache the game's shadow maps. After DLSS we only have the final color.
+// For near-static pixels (tiny MV) with a *small* luma change (flicker band), blend
+// toward the previous output's luma while keeping chroma/HF — damps monitor/emissive
+// shimmer without freezing real light cuts.
+//
+// Include after Log() + D3D11. Call FeedLightStabApply on g.tex11[SLOT_OUTPUT] before blit.
+
+#pragma once
+
+#include <cmath>
+#include <cstring>
+
+struct FeedLightStabCfg
+{
+    int   enabled;     // light_stab=
+    float strength;    // 0..1 blend toward previous LF when flicker detected
+    float max_delta;   // relative luma delta above this = real change, do not damp
+    float min_delta;   // below this = noise floor, ignore
+    float mv_eps;      // |mv| in pixels below this counts as static
+};
+
+// Defaults: off until auto-profile / overlay enables. Strict mv_eps — only near-static pixels.
+static FeedLightStabCfg g_feed_lightstab_cfg = { 0, 0.35f, 0.06f, 0.004f, 0.18f };
+
+struct FeedLightStabState
+{
+    ID3D11Texture2D          *prev;
+    ID3D11ShaderResourceView *prev_srv;
+    ID3D11Texture2D          *tmp;
+    ID3D11RenderTargetView   *tmp_rtv;
+    ID3D11ShaderResourceView *tmp_srv;
+    ID3D11VertexShader       *vs;
+    ID3D11PixelShader        *ps;
+    ID3D11Buffer             *cb;
+    ID3D11SamplerState       *smp;
+    UINT w, h;
+    DXGI_FORMAT fmt;
+    bool ready;
+    bool have_prev;
+    char status[96];
+};
+
+static FeedLightStabState g_feed_lightstab = {};
+
+static void FeedLightStabRelease()
+{
+    if (g_feed_lightstab.prev_srv) { g_feed_lightstab.prev_srv->Release(); g_feed_lightstab.prev_srv = nullptr; }
+    if (g_feed_lightstab.prev) { g_feed_lightstab.prev->Release(); g_feed_lightstab.prev = nullptr; }
+    if (g_feed_lightstab.tmp_srv) { g_feed_lightstab.tmp_srv->Release(); g_feed_lightstab.tmp_srv = nullptr; }
+    if (g_feed_lightstab.tmp_rtv) { g_feed_lightstab.tmp_rtv->Release(); g_feed_lightstab.tmp_rtv = nullptr; }
+    if (g_feed_lightstab.tmp) { g_feed_lightstab.tmp->Release(); g_feed_lightstab.tmp = nullptr; }
+    if (g_feed_lightstab.vs) { g_feed_lightstab.vs->Release(); g_feed_lightstab.vs = nullptr; }
+    if (g_feed_lightstab.ps) { g_feed_lightstab.ps->Release(); g_feed_lightstab.ps = nullptr; }
+    if (g_feed_lightstab.cb) { g_feed_lightstab.cb->Release(); g_feed_lightstab.cb = nullptr; }
+    if (g_feed_lightstab.smp) { g_feed_lightstab.smp->Release(); g_feed_lightstab.smp = nullptr; }
+    g_feed_lightstab.w = g_feed_lightstab.h = 0;
+    g_feed_lightstab.ready = false;
+    g_feed_lightstab.have_prev = false;
+}
+
+static bool FeedLightStabEnsureShaders(ID3D11Device *dev)
+{
+    if (g_feed_lightstab.vs && g_feed_lightstab.ps && g_feed_lightstab.cb && g_feed_lightstab.smp)
+        return true;
+    if (dev == nullptr) return false;
+
+    typedef HRESULT (WINAPI *pD3DCompile)(LPCVOID, SIZE_T, LPCSTR, const D3D_SHADER_MACRO *,
+                                          ID3DInclude *, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob **, ID3DBlob **);
+    HMODULE m = LoadLibraryW(L"d3dcompiler_47.dll");
+    auto compile = m ? reinterpret_cast<pD3DCompile>(GetProcAddress(m, "D3DCompile")) : nullptr;
+    if (!compile) { Log("[feed] lightstab: no d3dcompiler"); return false; }
+
+    static const char kSrc[] =
+        "Texture2D cur_tex : register(t0);\n"
+        "Texture2D prev_tex : register(t1);\n"
+        "Texture2D mv_tex : register(t2);\n"
+        "SamplerState smp : register(s0);\n"
+        "cbuffer CB : register(b0) {\n"
+        "  float strength; float max_delta; float min_delta; float mv_eps;\n"
+        "  float has_prev; float has_mv; float2 pad;\n"
+        "};\n"
+        "struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };\n"
+        "VSOut vs(uint id : SV_VertexID) { VSOut o; float2 uv = float2((id << 1) & 2, id & 2);\n"
+        "  o.uv = uv; o.pos = float4(uv * float2(2,-2) + float2(-1,1), 0, 1); return o; }\n"
+        "float Luma(float3 c) { return dot(c, float3(0.2126, 0.7152, 0.0722)); }\n"
+        "float4 ps(VSOut i) : SV_Target {\n"
+        "  float3 cur = cur_tex.SampleLevel(smp, i.uv, 0).rgb;\n"
+        "  if (has_prev < 0.5) return float4(cur, 1);\n"
+        "  // No MV => do not damp (avoids camera-pan throb when vectors are missing).\n"
+        "  if (has_mv < 0.5) return float4(cur, 1);\n"
+        "  float3 prev = prev_tex.SampleLevel(smp, i.uv, 0).rgb;\n"
+        "  float lc = max(Luma(cur), 1e-4); float lp = max(Luma(prev), 1e-4);\n"
+        "  float rel = abs(lc - lp) / max(lc, lp);\n"
+        "  float2 mv = mv_tex.SampleLevel(smp, i.uv, 0).xy;\n"
+        "  float mvlen = length(mv);\n"
+        "  // Hard gate: only pixels with |MV| <= mv_eps (near-static). No soft bleed into pans.\n"
+        "  if (mvlen > mv_eps) return float4(cur, 1);\n"
+        "  float band = (rel >= min_delta && rel <= max_delta) ? 1.0 : 0.0;\n"
+        "  float w = saturate(strength) * band;\n"
+        "  // Keep chroma of current; pull luma toward previous (dampen flicker).\n"
+        "  float new_l = lerp(lc, lp, w);\n"
+        "  float3 outc = cur * (new_l / lc);\n"
+        "  return float4(outc, 1);\n"
+        "}\n";
+
+    ID3DBlob *vs = nullptr, *ps = nullptr, *err = nullptr;
+    HRESULT hr = compile(kSrc, sizeof(kSrc) - 1, "lightstab", nullptr, nullptr, "vs", "vs_5_0", 0, 0, &vs, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] lightstab VS fail 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        return false;
+    }
+    if (err) { err->Release(); err = nullptr; }
+    hr = compile(kSrc, sizeof(kSrc) - 1, "lightstab", nullptr, nullptr, "ps", "ps_5_0", 0, 0, &ps, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] lightstab PS fail 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        if (vs) vs->Release();
+        return false;
+    }
+    if (err) err->Release();
+
+    hr = dev->CreateVertexShader(vs->GetBufferPointer(), vs->GetBufferSize(), nullptr, &g_feed_lightstab.vs);
+    if (SUCCEEDED(hr))
+        hr = dev->CreatePixelShader(ps->GetBufferPointer(), ps->GetBufferSize(), nullptr, &g_feed_lightstab.ps);
+    vs->Release();
+    ps->Release();
+    if (FAILED(hr)) { FeedLightStabRelease(); return false; }
+
+    D3D11_BUFFER_DESC cbd = {};
+    cbd.ByteWidth = 32;
+    cbd.Usage = D3D11_USAGE_DYNAMIC;
+    cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    if (FAILED(dev->CreateBuffer(&cbd, nullptr, &g_feed_lightstab.cb)))
+    { FeedLightStabRelease(); return false; }
+
+    D3D11_SAMPLER_DESC sd = {};
+    sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+    sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    if (FAILED(dev->CreateSamplerState(&sd, &g_feed_lightstab.smp)))
+    { FeedLightStabRelease(); return false; }
+
+    return true;
+}
+
+static bool FeedLightStabEnsureTargets(ID3D11Device *dev, UINT w, UINT h, DXGI_FORMAT fmt)
+{
+    if (g_feed_lightstab.prev && g_feed_lightstab.tmp &&
+        g_feed_lightstab.w == w && g_feed_lightstab.h == h && g_feed_lightstab.fmt == fmt)
+        return true;
+
+    if (g_feed_lightstab.prev_srv) { g_feed_lightstab.prev_srv->Release(); g_feed_lightstab.prev_srv = nullptr; }
+    if (g_feed_lightstab.prev) { g_feed_lightstab.prev->Release(); g_feed_lightstab.prev = nullptr; }
+    if (g_feed_lightstab.tmp_srv) { g_feed_lightstab.tmp_srv->Release(); g_feed_lightstab.tmp_srv = nullptr; }
+    if (g_feed_lightstab.tmp_rtv) { g_feed_lightstab.tmp_rtv->Release(); g_feed_lightstab.tmp_rtv = nullptr; }
+    if (g_feed_lightstab.tmp) { g_feed_lightstab.tmp->Release(); g_feed_lightstab.tmp = nullptr; }
+    g_feed_lightstab.have_prev = false;
+
+    D3D11_TEXTURE2D_DESC d = {};
+    d.Width = w; d.Height = h; d.MipLevels = 1; d.ArraySize = 1;
+    d.Format = fmt;
+    d.SampleDesc.Count = 1;
+    d.Usage = D3D11_USAGE_DEFAULT;
+    d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_lightstab.prev)) ||
+        FAILED(dev->CreateShaderResourceView(g_feed_lightstab.prev, nullptr, &g_feed_lightstab.prev_srv)))
+        return false;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_lightstab.tmp)) ||
+        FAILED(dev->CreateRenderTargetView(g_feed_lightstab.tmp, nullptr, &g_feed_lightstab.tmp_rtv)) ||
+        FAILED(dev->CreateShaderResourceView(g_feed_lightstab.tmp, nullptr, &g_feed_lightstab.tmp_srv)))
+        return false;
+
+    g_feed_lightstab.w = w;
+    g_feed_lightstab.h = h;
+    g_feed_lightstab.fmt = fmt;
+    g_feed_lightstab.ready = true;
+    return true;
+}
+
+// Stabilizes DLSS output in-place via tmp ping; updates prev history.
+// mv may be null. output must be SRV+RT capable (SLOT_OUTPUT is).
+static void FeedLightStabApply(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                               ID3D11Texture2D *output, ID3D11ShaderResourceView *output_srv,
+                               ID3D11Texture2D *mv, ID3D11ShaderResourceView *mv_srv,
+                               UINT w, UINT h)
+{
+    _snprintf_s(g_feed_lightstab.status, sizeof(g_feed_lightstab.status), _TRUNCATE, "LightStab: off");
+    if (g_feed_lightstab_cfg.enabled == 0 || dev == nullptr || ctx == nullptr ||
+        output == nullptr || output_srv == nullptr || w == 0 || h == 0)
+        return;
+
+    D3D11_TEXTURE2D_DESC od = {};
+    output->GetDesc(&od);
+    if (!FeedLightStabEnsureShaders(dev) || !FeedLightStabEnsureTargets(dev, w, h, od.Format))
+    {
+        _snprintf_s(g_feed_lightstab.status, sizeof(g_feed_lightstab.status), _TRUNCATE, "LightStab: init fail");
+        return;
+    }
+
+    // First frame: just seed history.
+    if (!g_feed_lightstab.have_prev)
+    {
+        ctx->CopyResource(g_feed_lightstab.prev, output);
+        g_feed_lightstab.have_prev = true;
+        _snprintf_s(g_feed_lightstab.status, sizeof(g_feed_lightstab.status), _TRUNCATE, "LightStab: seeded");
+        return;
+    }
+
+    D3D11_MAPPED_SUBRESOURCE mapped = {};
+    if (FAILED(ctx->Map(g_feed_lightstab.cb, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))
+        return;
+    float *f = (float *)mapped.pData;
+    f[0] = g_feed_lightstab_cfg.strength;
+    f[1] = g_feed_lightstab_cfg.max_delta;
+    f[2] = g_feed_lightstab_cfg.min_delta;
+    f[3] = g_feed_lightstab_cfg.mv_eps;
+    f[4] = 1.0f;
+    f[5] = (mv_srv != nullptr) ? 1.0f : 0.0f;
+    f[6] = 0.0f; f[7] = 0.0f;
+    ctx->Unmap(g_feed_lightstab.cb, 0);
+
+    ID3D11RenderTargetView *prev_rtv = nullptr;
+    ID3D11DepthStencilView *prev_dsv = nullptr;
+    ctx->OMGetRenderTargets(1, &prev_rtv, &prev_dsv);
+
+    D3D11_VIEWPORT vp = {};
+    vp.Width = (float)w; vp.Height = (float)h; vp.MaxDepth = 1.0f;
+    ctx->RSSetViewports(1, &vp);
+    ctx->OMSetRenderTargets(1, &g_feed_lightstab.tmp_rtv, nullptr);
+    ctx->IASetInputLayout(nullptr);
+    ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ctx->VSSetShader(g_feed_lightstab.vs, nullptr, 0);
+    ctx->PSSetShader(g_feed_lightstab.ps, nullptr, 0);
+    ctx->PSSetConstantBuffers(0, 1, &g_feed_lightstab.cb);
+    ctx->PSSetSamplers(0, 1, &g_feed_lightstab.smp);
+
+    ID3D11ShaderResourceView *srvs[3] = { output_srv, g_feed_lightstab.prev_srv, mv_srv };
+    ctx->PSSetShaderResources(0, 3, srvs);
+    ctx->Draw(3, 0);
+
+    ID3D11ShaderResourceView *nulls[3] = {};
+    ctx->PSSetShaderResources(0, 3, nulls);
+    ctx->OMSetRenderTargets(1, &prev_rtv, prev_dsv);
+    if (prev_rtv) prev_rtv->Release();
+    if (prev_dsv) prev_dsv->Release();
+
+    // Write stabilized result back to OUTPUT and refresh history.
+    ctx->CopyResource(output, g_feed_lightstab.tmp);
+    ctx->CopyResource(g_feed_lightstab.prev, g_feed_lightstab.tmp);
+
+    _snprintf_s(g_feed_lightstab.status, sizeof(g_feed_lightstab.status), _TRUNCATE,
+                "LightStab: on str=%.2f maxΔ=%.3f", g_feed_lightstab_cfg.strength,
+                g_feed_lightstab_cfg.max_delta);
+}

--- a/src/feed_ofa.h
+++ b/src/feed_ofa.h
@@ -1,0 +1,757 @@
+﻿// feed_ofa.h -- D3D11 NVIDIA Optical Flow (NVOFA) motion vectors for DLSS5-Feeder.
+//
+// Ported from NIGos/dlss5-bridge synth.inc OFA path (D3D11 only). Header-only;
+// include from dlss5-feed.cpp AFTER Log()/Warn() are defined.
+//
+// Returns full-res RG16F delta-UV motion vectors (prev = uv + mv), same convention
+// as Lumenite -- bridge measured no sign flip with inputFrame=current,
+// referenceFrame=previous. Default cfg is OFF so Lumenite remains the MV source
+// until the caller enables this path.
+
+#pragma once
+
+#include <windows.h>
+#include <d3d11.h>
+#include <d3dcompiler.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstddef>
+
+// Log() must already be defined by the including translation unit (dlss5-feed.cpp).
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+struct FeedOfaCfg
+{
+    int enabled;   // 0/1
+    int grid;      // 1|2|4 (0 = engine off)
+    int perf;      // 5 SLOW | 10 MEDIUM | 20 FAST
+};
+
+static FeedOfaCfg g_feed_ofa_cfg = { 0, 2, 10 };
+
+static bool FeedOfaReady();
+static void FeedOfaShutdown();
+
+// Borrowed pointer to the module-owned RG16F full-res MV texture, or nullptr.
+// Do NOT AddRef -- lifetime is owned here until shutdown/rebuild.
+static ID3D11Texture2D *FeedOfaUpdate(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                                      ID3D11Texture2D *color_src, DXGI_FORMAT color_fmt,
+                                      UINT w, UINT h);
+
+// ---------------------------------------------------------------------------
+// Local helpers (self-contained; do not depend on bridge.inc)
+// Anonymous namespace so FormatName does not collide with dlss5-feed.cpp's own.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+static const char *OfaFormatName(DXGI_FORMAT f)
+{
+    switch (f)
+    {
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:    return "R16G16B16A16_FLOAT";
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS: return "R16G16B16A16_TYPELESS";
+    case DXGI_FORMAT_R11G11B10_FLOAT:       return "R11G11B10_FLOAT";
+    case DXGI_FORMAT_R10G10B10A2_UNORM:     return "R10G10B10A2_UNORM";
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:  return "R10G10B10A2_TYPELESS";
+    case DXGI_FORMAT_R8G8B8A8_UNORM:        return "R8G8B8A8_UNORM";
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:   return "R8G8B8A8_UNORM_SRGB";
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:     return "R8G8B8A8_TYPELESS";
+    case DXGI_FORMAT_B8G8R8A8_UNORM:        return "B8G8R8A8_UNORM";
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:   return "B8G8R8A8_UNORM_SRGB";
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:     return "B8G8R8A8_TYPELESS";
+    case DXGI_FORMAT_B8G8R8X8_UNORM:        return "B8G8R8X8_UNORM";
+    case DXGI_FORMAT_R16G16_FLOAT:          return "R16G16_FLOAT";
+    case DXGI_FORMAT_R16G16_SINT:           return "R16G16_SINT";
+    case DXGI_FORMAT_R32_FLOAT:             return "R32_FLOAT";
+    default:                                return "?";
+    }
+}
+
+static DXGI_FORMAT FeedOfaTypedFormat(DXGI_FORMAT f)
+{
+    switch (f)
+    {
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS: case DXGI_FORMAT_R8G8B8A8_UNORM: case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS: case DXGI_FORMAT_B8G8R8A8_UNORM: case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS: case DXGI_FORMAT_B8G8R8X8_UNORM: case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8X8_UNORM;
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS: case DXGI_FORMAT_R10G10B10A2_UNORM:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS: case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        return DXGI_FORMAT_R11G11B10_FLOAT;
+    default:
+        return f;
+    }
+}
+
+static bool FeedOfaFormatCanExceedOne(DXGI_FORMAT f)
+{
+    switch (f)
+    {
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+typedef HRESULT (WINAPI *PFN_FeedOfa_D3DCompile)(
+    LPCVOID, SIZE_T, LPCSTR, const D3D_SHADER_MACRO *, ID3DInclude *,
+    LPCSTR, LPCSTR, UINT, UINT, ID3DBlob **, ID3DBlob **);
+
+static PFN_FeedOfa_D3DCompile LoadSystemD3DCompiler()
+{
+    HMODULE m = LoadLibraryW(L"d3dcompiler_47.dll");
+    if (m == nullptr) return nullptr;
+    return reinterpret_cast<PFN_FeedOfa_D3DCompile>(GetProcAddress(m, "D3DCompile"));
+}
+
+} // namespace (FormatName / LoadSystemD3DCompiler)
+
+// ---------------------------------------------------------------------------
+// NVOFA ABI (hand-written; measured against nvofapi64.dll D3D11 entry)
+// ---------------------------------------------------------------------------
+
+typedef long NvOfStatus;
+static const NvOfStatus kOfaSuccess = 0;
+static const NvOfStatus kOfaRaised  = 0x7FFFFFFF;
+
+struct NvOfInitParams
+{
+    uint32_t width;               //  0
+    uint32_t height;              //  4
+    uint32_t outGridSize;         //  8   1, 2 or 4
+    uint32_t hintGridSize;        // 12
+    uint32_t mode;                // 16   1 = NV_OF_MODE_OPTICALFLOW
+    uint32_t perfLevel;           // 20   5 SLOW, 10 MEDIUM, 20 FAST
+    uint32_t enableExternalHints; // 24
+    uint32_t enableOutputCost;    // 28
+    void    *hPrivData;           // 32
+    uint32_t disparityRange;      // 40
+    uint32_t enableRoi;           // 44
+};
+
+struct NvOfExecuteInputParams
+{
+    void    *inputFrame;           //  0  CURRENT
+    void    *referenceFrame;       //  8  PREVIOUS
+    void    *externalHints;        // 16
+    uint32_t disableTemporalHints; // 24
+    uint32_t padding;              // 28
+    void    *hPrivData;            // 32
+    uint32_t padding2;             // 40
+    uint32_t numRois;              // 44
+    void    *roiData;              // 48
+};
+
+struct NvOfExecuteOutputParams { void *outputBuffer; void *outputCostBuffer; void *hPrivData; };
+
+static_assert(sizeof(NvOfInitParams) == 48 && offsetof(NvOfInitParams, hPrivData) == 32,
+              "NvOfInitParams does not match the layout measured against the driver");
+static_assert(sizeof(NvOfExecuteInputParams) == 56 &&
+              offsetof(NvOfExecuteInputParams, numRois) == 44,
+              "NvOfExecuteInputParams does not match the layout measured against the driver");
+
+typedef NvOfStatus (__stdcall *PFN_OfaCreateInstance)(uint32_t, void *);
+typedef NvOfStatus (__stdcall *PFN_OfaCreateD3D11)(ID3D11Device *, ID3D11DeviceContext *, void **);
+typedef NvOfStatus (__stdcall *PFN_OfaInit)(void *, const NvOfInitParams *);
+typedef NvOfStatus (__stdcall *PFN_OfaRegister)(void *, ID3D11Resource *, void **);
+typedef NvOfStatus (__stdcall *PFN_OfaUnregister)(void *);
+typedef NvOfStatus (__stdcall *PFN_OfaExecute)(void *, const NvOfExecuteInputParams *,
+                                               NvOfExecuteOutputParams *);
+typedef NvOfStatus (__stdcall *PFN_OfaDestroy)(void *);
+typedef NvOfStatus (__stdcall *PFN_OfaLastError)(void *, char *, uint32_t *);
+
+static const char *OfaStatusName(NvOfStatus s)
+{
+    switch (s)
+    {
+    case 0:  return "SUCCESS";
+    case 1:  return "INVALID_PTR";
+    case 2:  return "INVALID_PARAM";
+    case 3:  return "INVALID_CALL";
+    case 4:  return "INVALID_VERSION";
+    case 5:  return "OUT_OF_MEMORY";
+    case 6:  return "NOT_INITIALIZED";
+    case 7:  return "UNSUPPORTED_FEATURE";
+    case 8:  return "GENERIC";
+    case 9:  return "OF_NOT_AVAILABLE";
+    case 10: return "UNSUPPORTED_DEVICE";
+    case 11: return "DEVICE_DOES_NOT_EXIST";
+    case static_cast<NvOfStatus>(0x80004005): return "E_FAIL, not an NV_OF_STATUS";
+    default: return "a status this build has no name for";
+    }
+}
+
+static const char *FeedOfaPerfName(int p)
+{
+    return p == 5 ? "SLOW" : p == 10 ? "MEDIUM" : p == 20 ? "FAST" : "?";
+}
+
+// ---------------------------------------------------------------------------
+// Session state
+// ---------------------------------------------------------------------------
+
+struct FeedOfaState
+{
+    bool    tried;
+    bool    ready;
+    bool    stopped;
+    bool    primed;
+    bool    first_said;
+    HMODULE lib;
+    void   *slot[64];
+    void   *session;
+    UINT    w, h, grid;
+    int     perf;
+    DXGI_FORMAT back_fmt;
+    ID3D11Device *dev;          // bare address for comparison only
+    void   *reg_src[2], *reg_flow;
+    ID3D11Texture2D *copy, *src[2], *flow, *mv;
+    ID3D11ShaderResourceView  *copy_srv, *flow_srv;
+    ID3D11UnorderedAccessView *src_uav[2], *mv_uav;
+    ID3D11ComputeShader *luma_cs, *flow_cs;
+    int    cur;
+    int    fails;
+    UINT64 frames;
+};
+
+static FeedOfaState g_ofa = {};
+
+static bool FeedOfaReady() { return g_ofa.ready; }
+
+// ---------------------------------------------------------------------------
+// SEH wrappers (EXCEPTION_EXECUTE_HANDLER -- no CaptureFault)
+// ---------------------------------------------------------------------------
+
+static NvOfStatus OfaSafeCreateInstance(PFN_OfaCreateInstance fn, uint32_t ver, void *slots)
+{
+    __try { return fn(ver, slots); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeCreateSession(PFN_OfaCreateD3D11 fn, ID3D11Device *d,
+                                       ID3D11DeviceContext *c, void **out)
+{
+    __try { return fn(d, c, out); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeInit(PFN_OfaInit fn, void *s, const NvOfInitParams *p)
+{
+    __try { return fn(s, p); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeRegister(PFN_OfaRegister fn, void *s, ID3D11Resource *r, void **out)
+{
+    __try { return fn(s, r, out); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeUnregister(PFN_OfaUnregister fn, void *h)
+{
+    __try { return fn(h); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeDestroy(PFN_OfaDestroy fn, void *s)
+{
+    __try { return fn(s); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeExecute(PFN_OfaExecute fn, void *s, const NvOfExecuteInputParams *in,
+                                 NvOfExecuteOutputParams *out)
+{
+    __try { return fn(s, in, out); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return kOfaRaised; }
+}
+
+static void OfaLastError(char *dst, size_t cap)
+{
+    dst[0] = '\0';
+    if (g_ofa.session == nullptr || g_ofa.slot[8] == nullptr) return;
+    uint32_t n = static_cast<uint32_t>(cap);
+    auto fn = reinterpret_cast<PFN_OfaLastError>(g_ofa.slot[8]);
+    __try { fn(g_ofa.session, dst, &n); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { dst[0] = '\0'; }
+    dst[cap - 1] = '\0';
+}
+
+// ---------------------------------------------------------------------------
+// Teardown (session + GPU objects; DLL kept until FeedOfaShutdown)
+// ---------------------------------------------------------------------------
+
+static void FeedOfaClose()
+{
+    auto unreg = reinterpret_cast<PFN_OfaUnregister>(g_ofa.slot[5]);
+    if (unreg != nullptr)
+    {
+        for (int i = 0; i < 2; ++i)
+            if (g_ofa.reg_src[i] != nullptr) OfaSafeUnregister(unreg, g_ofa.reg_src[i]);
+        if (g_ofa.reg_flow != nullptr) OfaSafeUnregister(unreg, g_ofa.reg_flow);
+    }
+    g_ofa.reg_src[0] = g_ofa.reg_src[1] = g_ofa.reg_flow = nullptr;
+
+    if (g_ofa.copy_srv != nullptr) { g_ofa.copy_srv->Release(); g_ofa.copy_srv = nullptr; }
+    if (g_ofa.flow_srv != nullptr) { g_ofa.flow_srv->Release(); g_ofa.flow_srv = nullptr; }
+    if (g_ofa.mv_uav   != nullptr) { g_ofa.mv_uav->Release();   g_ofa.mv_uav   = nullptr; }
+    for (int i = 0; i < 2; ++i)
+        if (g_ofa.src_uav[i] != nullptr) { g_ofa.src_uav[i]->Release(); g_ofa.src_uav[i] = nullptr; }
+
+    if (g_ofa.copy != nullptr) { g_ofa.copy->Release(); g_ofa.copy = nullptr; }
+    for (int i = 0; i < 2; ++i)
+        if (g_ofa.src[i] != nullptr) { g_ofa.src[i]->Release(); g_ofa.src[i] = nullptr; }
+    if (g_ofa.flow != nullptr) { g_ofa.flow->Release(); g_ofa.flow = nullptr; }
+    if (g_ofa.mv   != nullptr) { g_ofa.mv->Release();   g_ofa.mv   = nullptr; }
+
+    if (g_ofa.luma_cs != nullptr) { g_ofa.luma_cs->Release(); g_ofa.luma_cs = nullptr; }
+    if (g_ofa.flow_cs != nullptr) { g_ofa.flow_cs->Release(); g_ofa.flow_cs = nullptr; }
+
+    if (g_ofa.session != nullptr)
+    {
+        auto destroy = reinterpret_cast<PFN_OfaDestroy>(g_ofa.slot[7]);
+        if (destroy != nullptr) OfaSafeDestroy(destroy, g_ofa.session);
+        g_ofa.session = nullptr;
+    }
+
+    g_ofa.ready  = false;
+    g_ofa.primed = false;
+    g_ofa.fails  = 0;
+    g_ofa.cur    = 0;
+    g_ofa.dev    = nullptr;
+}
+
+static void FeedOfaShutdown()
+{
+    FeedOfaClose();
+    if (g_ofa.lib != nullptr)
+    {
+        FreeLibrary(g_ofa.lib);
+        g_ofa.lib = nullptr;
+    }
+    memset(g_ofa.slot, 0, sizeof(g_ofa.slot));
+    g_ofa.tried      = false;
+    g_ofa.stopped    = false;
+    g_ofa.first_said = false;
+    g_ofa.frames     = 0;
+    g_ofa.w = g_ofa.h = g_ofa.grid = 0;
+    g_ofa.perf = 0;
+    g_ofa.back_fmt = DXGI_FORMAT_UNKNOWN;
+}
+
+// ---------------------------------------------------------------------------
+// Shaders (HLSL copied from bridge kOfaLuma* / kOfaFlowSrc)
+// ---------------------------------------------------------------------------
+
+static const char kOfaLumaHead[] =
+    "Texture2D<float4>   src : register(t0);\n"
+    "RWTexture2D<float4> dst : register(u0);\n"
+    "[numthreads(8,8,1)]\n"
+    "void main(uint3 id : SV_DispatchThreadID)\n"
+    "{\n"
+    "    uint w, h; dst.GetDimensions(w, h);\n"
+    "    if (id.x >= w || id.y >= h) return;\n"
+    "    float3 c = src[id.xy].rgb;\n"
+    "    float  l = dot(c, float3(0.2126, 0.7152, 0.0722));\n";
+static const char kOfaLumaTonemap[] = "    l = l / (l + 1.0);\n";
+static const char kOfaLumaClamp[]   = "    l = saturate(l);\n";
+static const char kOfaLumaTail[] =
+    "    dst[id.xy] = float4(l, l, l, 1.0);\n"
+    "}\n";
+
+static const char kOfaFlowSrc[] =
+    "Texture2D<int2>     flow : register(t0);\n"
+    "RWTexture2D<float2> dst  : register(u0);\n"
+    "[numthreads(8,8,1)]\n"
+    "void main(uint3 id : SV_DispatchThreadID)\n"
+    "{\n"
+    "    uint w, h, fw, fh;\n"
+    "    dst.GetDimensions(w, h);\n"
+    "    flow.GetDimensions(fw, fh);\n"
+    "    if (id.x >= w || id.y >= h) return;\n"
+    "    uint2 c = min(uint2(id.x * fw / w, id.y * fh / h), uint2(fw - 1, fh - 1));\n"
+    "    dst[id.xy] = float2(flow[c]) * (1.0 / 32.0) / float2(w, h);\n"
+    "}\n";
+
+static bool OfaMakeShader(ID3D11Device *dev11, const char *src, const char *name,
+                          ID3D11ComputeShader **out)
+{
+    if (*out != nullptr) return true;
+
+    PFN_FeedOfa_D3DCompile compile = LoadSystemD3DCompiler();
+    if (compile == nullptr)
+    {
+        Log("[feed] optical flow: d3dcompiler_47.dll is unavailable, so the flow "
+            "conversion shader cannot be built");
+        return false;
+    }
+
+    ID3DBlob *code = nullptr, *err = nullptr;
+    HRESULT hr = compile(src, strlen(src), name, nullptr, nullptr, "main", "cs_5_0", 0, 0,
+                         &code, &err);
+    if (FAILED(hr) || code == nullptr)
+    {
+        Log("[feed] optical flow shader compile failed 0x%08X: %s", hr,
+            err != nullptr ? static_cast<const char *>(err->GetBufferPointer()) : "");
+        if (err != nullptr) err->Release();
+        return false;
+    }
+    if (err != nullptr) err->Release();
+
+    hr = dev11->CreateComputeShader(code->GetBufferPointer(), code->GetBufferSize(), nullptr, out);
+    code->Release();
+    if (FAILED(hr))
+    {
+        Log("[feed] optical flow CreateComputeShader failed 0x%08X", hr);
+        return false;
+    }
+    return true;
+}
+
+static ID3D11Texture2D *OfaMakeTexture(ID3D11Device *dev11, UINT w, UINT h, DXGI_FORMAT fmt,
+                                       UINT bind, const char *what)
+{
+    D3D11_TEXTURE2D_DESC td = {};
+    td.Width = w; td.Height = h; td.MipLevels = 1; td.ArraySize = 1;
+    td.Format = fmt; td.SampleDesc.Count = 1;
+    td.Usage = D3D11_USAGE_DEFAULT; td.BindFlags = bind;
+
+    ID3D11Texture2D *t = nullptr;
+    const HRESULT hr = dev11->CreateTexture2D(&td, nullptr, &t);
+    if (FAILED(hr))
+    {
+        Log("[feed] optical flow: could not create the %ux%u %s texture for %s: 0x%08X",
+            w, h, OfaFormatName(fmt), what, hr);
+        return nullptr;
+    }
+    return t;
+}
+
+// ---------------------------------------------------------------------------
+// Session open
+// ---------------------------------------------------------------------------
+
+static bool FeedOfaOpen(ID3D11Device *dev11, ID3D11DeviceContext *ctx, UINT w, UINT h,
+                        DXGI_FORMAT back_fmt)
+{
+    g_ofa.tried = true;
+    g_ofa.w = w; g_ofa.h = h; g_ofa.back_fmt = back_fmt; g_ofa.dev = dev11;
+    g_ofa.grid = static_cast<UINT>(g_feed_ofa_cfg.grid);
+    g_ofa.perf = g_feed_ofa_cfg.perf;
+
+    if (g_ofa.grid == 0)
+    {
+        Log("[feed] optical flow: grid is 0, which switches the engine off, so "
+            "the session is not opened.");
+        return false;
+    }
+
+    if (g_ofa.lib == nullptr)
+    {
+        g_ofa.lib = LoadLibraryW(L"nvofapi64.dll");
+        if (g_ofa.lib == nullptr)
+        {
+            Log("[feed] optical flow: nvofapi64.dll is not loadable in this process. It is "
+                "installed with the display driver, so this means no NVIDIA driver here "
+                "rather than a driver too old.");
+            return false;
+        }
+        auto create = reinterpret_cast<PFN_OfaCreateInstance>(
+            GetProcAddress(g_ofa.lib, "NvOFAPICreateInstanceD3D11"));
+        if (create == nullptr)
+        {
+            Log("[feed] optical flow: nvofapi64.dll exports no NvOFAPICreateInstanceD3D11.");
+            return false;
+        }
+        const NvOfStatus r = OfaSafeCreateInstance(create, 0x20, g_ofa.slot);
+        if (r != kOfaSuccess)
+        {
+            Log("[feed] optical flow: this driver refused API version 0x20 with status %ld "
+                "(%s). The D3D11 entry accepts 0x10 through 0x50 on the driver this was "
+                "measured against.", r, OfaStatusName(r));
+            memset(g_ofa.slot, 0, sizeof(g_ofa.slot));
+            return false;
+        }
+    }
+
+    {
+        D3D11_FEATURE_DATA_FORMAT_SUPPORT2 f2 = {};
+        f2.InFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+        if (FAILED(dev11->CheckFeatureSupport(D3D11_FEATURE_FORMAT_SUPPORT2, &f2, sizeof(f2))) ||
+            (f2.OutFormatSupport2 & D3D11_FORMAT_SUPPORT2_UAV_TYPED_STORE) == 0)
+        {
+            Log("[feed] optical flow: this device cannot store to a B8G8R8A8_UNORM "
+                "unordered access view, so the colour frame cannot be converted into the "
+                "only 4-channel format the flow engine accepts.");
+            return false;
+        }
+    }
+
+    {
+        const bool hdrish = FeedOfaFormatCanExceedOne(back_fmt);
+        char luma[sizeof(kOfaLumaHead) + sizeof(kOfaLumaTonemap) + sizeof(kOfaLumaTail) + 8];
+        _snprintf_s(luma, sizeof(luma), _TRUNCATE, "%s%s%s", kOfaLumaHead,
+                    hdrish ? kOfaLumaTonemap : kOfaLumaClamp, kOfaLumaTail);
+        if (!OfaMakeShader(dev11, luma, "ofaluma", &g_ofa.luma_cs)) return false;
+        Log("[feed] optical flow: luma is %s, because the colour source is %s.",
+            hdrish ? "tone-mapped with l/(l+1) before the 8-bit conversion"
+                   : "clamped rather than tone-mapped, so all eight bits of the "
+                     "engine's input carry signal",
+            OfaFormatName(back_fmt));
+    }
+    if (!OfaMakeShader(dev11, kOfaFlowSrc, "ofaflow", &g_ofa.flow_cs)) return false;
+
+    const UINT fw = (w + g_ofa.grid - 1) / g_ofa.grid;
+    const UINT fh = (h + g_ofa.grid - 1) / g_ofa.grid;
+
+    g_ofa.copy = OfaMakeTexture(dev11, w, h, FeedOfaTypedFormat(back_fmt),
+                                D3D11_BIND_SHADER_RESOURCE, "the colour copy");
+    for (int i = 0; i < 2; ++i)
+        g_ofa.src[i] = OfaMakeTexture(dev11, w, h, DXGI_FORMAT_B8G8R8A8_UNORM,
+                                      D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE,
+                                      i == 0 ? "the current frame" : "the previous frame");
+    g_ofa.flow = OfaMakeTexture(dev11, fw, fh, DXGI_FORMAT_R16G16_SINT,
+                                D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS,
+                                "the flow field");
+    g_ofa.mv = OfaMakeTexture(dev11, w, h, DXGI_FORMAT_R16G16_FLOAT,
+                              D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE,
+                              "the motion vectors");
+    if (g_ofa.copy == nullptr || g_ofa.src[0] == nullptr || g_ofa.src[1] == nullptr ||
+        g_ofa.flow == nullptr || g_ofa.mv == nullptr)
+    { FeedOfaClose(); return false; }
+
+    HRESULT hr = dev11->CreateShaderResourceView(g_ofa.copy, nullptr, &g_ofa.copy_srv);
+    if (SUCCEEDED(hr)) hr = dev11->CreateShaderResourceView(g_ofa.flow, nullptr, &g_ofa.flow_srv);
+    for (int i = 0; i < 2 && SUCCEEDED(hr); ++i)
+        hr = dev11->CreateUnorderedAccessView(g_ofa.src[i], nullptr, &g_ofa.src_uav[i]);
+    if (SUCCEEDED(hr)) hr = dev11->CreateUnorderedAccessView(g_ofa.mv, nullptr, &g_ofa.mv_uav);
+    if (FAILED(hr))
+    {
+        Log("[feed] optical flow: a view over one of the textures could not be "
+            "created: 0x%08X", hr);
+        FeedOfaClose();
+        return false;
+    }
+
+    auto create_ses = reinterpret_cast<PFN_OfaCreateD3D11>(g_ofa.slot[0]);
+    NvOfStatus r = OfaSafeCreateSession(create_ses, dev11, ctx, &g_ofa.session);
+    if (r != kOfaSuccess || g_ofa.session == nullptr)
+    {
+        Log("[feed] optical flow: the driver will not open a session on this D3D11 device: "
+            "status %ld (%s). This is what a game rendering on an adapter other than the "
+            "NVIDIA one looks like, which happens on a hybrid laptop.", r, OfaStatusName(r));
+        g_ofa.session = nullptr;
+        FeedOfaClose();
+        return false;
+    }
+
+    NvOfInitParams ip;
+    memset(&ip, 0, sizeof(ip));
+    ip.width = w; ip.height = h;
+    ip.outGridSize = g_ofa.grid;
+    ip.hintGridSize = g_ofa.grid;
+    ip.mode = 1;
+    ip.perfLevel = static_cast<uint32_t>(g_ofa.perf);
+    auto init = reinterpret_cast<PFN_OfaInit>(g_ofa.slot[1]);
+    r = OfaSafeInit(init, g_ofa.session, &ip);
+    if (r != kOfaSuccess)
+    {
+        char msg[512];
+        OfaLastError(msg, sizeof(msg));
+        Log("[feed] optical flow: nvOFInit refused %ux%u at grid %u with 0x%08lX (%s). %s",
+            w, h, g_ofa.grid, static_cast<unsigned long>(r), OfaStatusName(r), msg);
+        if (r == 5)
+            Log("[feed] optical flow: Grid 2 needs about 109 MB driver-side at 3840x1600; "
+                "grid 4 needs about 63 MB. Try grid=4.");
+        FeedOfaClose();
+        return false;
+    }
+
+    auto reg = reinterpret_cast<PFN_OfaRegister>(g_ofa.slot[4]);
+    NvOfStatus r0 = OfaSafeRegister(reg, g_ofa.session, g_ofa.src[0],  &g_ofa.reg_src[0]);
+    NvOfStatus r1 = OfaSafeRegister(reg, g_ofa.session, g_ofa.src[1],  &g_ofa.reg_src[1]);
+    NvOfStatus r2 = OfaSafeRegister(reg, g_ofa.session, g_ofa.flow,    &g_ofa.reg_flow);
+    if (r0 != kOfaSuccess || r1 != kOfaSuccess || r2 != kOfaSuccess ||
+        g_ofa.reg_src[0] == nullptr || g_ofa.reg_src[1] == nullptr || g_ofa.reg_flow == nullptr)
+    {
+        char msg[512];
+        OfaLastError(msg, sizeof(msg));
+        Log("[feed] optical flow: registering the three buffers was refused (%ld, %ld, %ld). %s",
+            r0, r1, r2, msg);
+        FeedOfaClose();
+        return false;
+    }
+
+    g_ofa.ready   = true;
+    g_ofa.stopped = false;
+
+    Log("[feed] optical flow: nvofapi64.dll loaded, instance at API 0x20, session open on "
+        "the game's D3D11 device. Grid %u, perf %s, flow %ux%u R16G16_SINT -> %ux%u "
+        "R16G16_FLOAT.",
+        g_ofa.grid, FeedOfaPerfName(g_ofa.perf), fw, fh, w, h);
+    Log("[feed] optical flow: conversion shaders ready (cs_5_0)");
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Per-frame dispatch (save/restore CS bindings)
+// ---------------------------------------------------------------------------
+
+static void OfaDispatch(ID3D11DeviceContext *ctx, ID3D11ComputeShader *cs,
+                        ID3D11ShaderResourceView *srv, ID3D11UnorderedAccessView *uav,
+                        UINT w, UINT h)
+{
+    ID3D11ComputeShader       *old_cs  = nullptr;
+    ID3D11ShaderResourceView  *old_srv = nullptr;
+    ID3D11UnorderedAccessView *old_uav = nullptr;
+    ctx->CSGetShader(&old_cs, nullptr, nullptr);
+    ctx->CSGetShaderResources(0, 1, &old_srv);
+    ctx->CSGetUnorderedAccessViews(0, 1, &old_uav);
+
+    UINT keep = static_cast<UINT>(-1);
+    ctx->CSSetShader(cs, nullptr, 0);
+    ctx->CSSetShaderResources(0, 1, &srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &uav, &keep);
+    ctx->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+
+    ID3D11ShaderResourceView  *no_srv = nullptr;
+    ID3D11UnorderedAccessView *no_uav = nullptr;
+    ctx->CSSetShaderResources(0, 1, &no_srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &no_uav, &keep);
+
+    ctx->CSSetShader(old_cs, nullptr, 0);
+    ctx->CSSetShaderResources(0, 1, &old_srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &old_uav, &keep);
+    if (old_cs  != nullptr) old_cs->Release();
+    if (old_srv != nullptr) old_srv->Release();
+    if (old_uav != nullptr) old_uav->Release();
+}
+
+static bool FeedOfaShapeChanged(ID3D11Device *dev, DXGI_FORMAT fmt, UINT w, UINT h)
+{
+    return g_ofa.w != w || g_ofa.h != h || g_ofa.back_fmt != fmt || g_ofa.dev != dev ||
+           g_ofa.grid != static_cast<UINT>(g_feed_ofa_cfg.grid) ||
+           g_ofa.perf != g_feed_ofa_cfg.perf;
+}
+
+// ---------------------------------------------------------------------------
+// FeedOfaUpdate -- one colour frame in, full-res RG16F MV out (or nullptr)
+// ---------------------------------------------------------------------------
+
+static ID3D11Texture2D *FeedOfaUpdate(ID3D11Device *dev, ID3D11DeviceContext *ctx,
+                                      ID3D11Texture2D *color_src, DXGI_FORMAT color_fmt,
+                                      UINT w, UINT h)
+{
+    if (g_feed_ofa_cfg.enabled == 0 || g_feed_ofa_cfg.grid == 0)
+        return nullptr;
+    if (dev == nullptr || ctx == nullptr || color_src == nullptr || w == 0 || h == 0)
+        return nullptr;
+
+    // Rebuild when shape or cfg knobs change (including retry after stopped/failed open).
+    if ((g_ofa.ready || g_ofa.tried) && FeedOfaShapeChanged(dev, color_fmt, w, h))
+    {
+        Log("[feed] optical flow: colour became %ux%u %s at grid %d perf %s on "
+            "device %p, so the session is rebuilt.", w, h, OfaFormatName(color_fmt),
+            g_feed_ofa_cfg.grid, FeedOfaPerfName(g_feed_ofa_cfg.perf),
+            static_cast<void *>(dev));
+        FeedOfaClose();
+        g_ofa.tried = false;
+        g_ofa.stopped = false;
+        if (!FeedOfaOpen(dev, ctx, w, h, color_fmt))
+        {
+            Log("[feed] optical flow: the session could not be rebuilt for the new size, "
+                "so this stops.");
+            g_ofa.stopped = true;
+            return nullptr;
+        }
+    }
+    else if (!g_ofa.ready && !g_ofa.tried && !g_ofa.stopped)
+    {
+        if (!FeedOfaOpen(dev, ctx, w, h, color_fmt))
+            return nullptr;
+    }
+
+    if (!g_ofa.ready || g_ofa.stopped)
+        return nullptr;
+
+    ctx->CopyResource(g_ofa.copy, color_src);
+    OfaDispatch(ctx, g_ofa.luma_cs, g_ofa.copy_srv, g_ofa.src_uav[g_ofa.cur], w, h);
+
+    if (!g_ofa.primed)
+    {
+        g_ofa.primed = true;
+        g_ofa.cur ^= 1;
+        if (!g_ofa.first_said)
+        {
+            g_ofa.first_said = true;
+            Log("[feed] optical flow: the first frame has no previous frame to compare "
+                "against, so nothing is delivered on it. Flow starts on the next one.");
+        }
+        return nullptr;
+    }
+
+    NvOfExecuteInputParams  in;
+    NvOfExecuteOutputParams eo;
+    memset(&in, 0, sizeof(in));
+    memset(&eo, 0, sizeof(eo));
+    in.inputFrame           = g_ofa.reg_src[g_ofa.cur];
+    in.referenceFrame       = g_ofa.reg_src[g_ofa.cur ^ 1];
+    in.disableTemporalHints = 1;
+    eo.outputBuffer         = g_ofa.reg_flow;
+
+    auto exec = reinterpret_cast<PFN_OfaExecute>(g_ofa.slot[6]);
+    const NvOfStatus r = OfaSafeExecute(exec, g_ofa.session, &in, &eo);
+    ++g_ofa.frames;
+
+    if (r == kOfaRaised)
+    {
+        Log("[feed] optical flow: nvOFExecute raised an exception, so this stops here. "
+            "The game keeps rendering on its own.");
+        g_ofa.ready   = false;
+        g_ofa.stopped = true;
+        return nullptr;
+    }
+    if (r != kOfaSuccess)
+    {
+        if (g_ofa.fails == 0 || g_ofa.fails == 2)
+        {
+            char msg[512];
+            OfaLastError(msg, sizeof(msg));
+            Log("[feed] optical flow: execute %llu refused with status %ld (%s). %s",
+                g_ofa.frames, r, OfaStatusName(r), msg);
+        }
+        // Advance cur: luma already overwrote src[cur]; leaving it would compare
+        // against a two-frame-old reference on the next success.
+        g_ofa.cur ^= 1;
+        if (++g_ofa.fails >= 3)
+        {
+            Log("[feed] optical flow: three consecutive failures, so this stops.");
+            g_ofa.ready   = false;
+            g_ofa.stopped = true;
+        }
+        return nullptr;
+    }
+
+    g_ofa.fails = 0;
+    OfaDispatch(ctx, g_ofa.flow_cs, g_ofa.flow_srv, g_ofa.mv_uav, w, h);
+    g_ofa.cur ^= 1;
+
+    // Borrowed -- module owns g_ofa.mv until Close/Shutdown.
+    return g_ofa.mv;
+}
+

--- a/src/feed_ofa_raw.inc
+++ b/src/feed_ofa_raw.inc
@@ -1,0 +1,1066 @@
+﻿// The driver's own optical flow engine
+//
+// Why this exists: Skyrim Special Edition, 2026-08-30. The synthetic contract
+// was built, the feature was created, frames were delivered, and fine detail
+// dissolved along the direction of movement -- worse slowly than quickly. Five
+// observations settled the cause by experiment: all four mv_sign combinations
+// smeared, so not the sign; mode=1 was clean, so not the transport;
+// reset_every=1 was clean, so it is the temporal accumulation; worse slowly, so
+// the sub-pixel regime; the trail ran ALONG the movement, so under-estimated
+// rather than reversed. vort_Shaders estimates at mip 1, its finest pass is
+// PS_Motion1, there is no PS_Motion0, and below one pixel it reports ~0.
+//
+// NVOFA never reports zero. Measured on this machine at 1920x1080, MEDIUM,
+// "exactly zero: 0.00%" at every step above 0.10 px, and at a true 0.10 px it
+// answers 0.156 at grid 2. That is the whole reason to build this.
+//
+// D3D11 ONLY. The function list below was recovered empirically for
+// NvOFAPICreateInstanceD3D11 and for nothing else: the D3D12 and Vulkan entry
+// points are different exports with different, unrecovered slot tables and
+// different accepted API versions. On those two runtimes the kSynthMv[1..]
+// ReShade providers are the only ones, which is what they already were.
+//
+// NOT MEASURED and not claimed anywhere below: rotation and zoom against real
+// game content, transparency, per-object motion, and temporal hints -- every
+// number quoted here was taken with disableTemporalHints = 1 over rigid warps of
+// a synthetic pattern.
+// ---------------------------------------------------------------------------
+
+typedef long NvOfStatus;
+static const NvOfStatus kOfaSuccess = 0;      // NV_OF_SUCCESS
+static const NvOfStatus kOfaRaised  = 0x7FFFFFFF;   // our own marker, as NGX_EXCEPTION_MARKER is
+
+// Plain C structs from a published ABI, hand-written for the same reason the
+// Vulkan structs next door are: there is no lib to link and no header worth
+// vendoring for five exports. This layout is additionally confirmed by
+// experiment on this machine -- breaking one field made the driver name that
+// exact field back through nvOFGetLastError.
+struct NvOfInitParams
+{
+    uint32_t width;               //  0
+    uint32_t height;              //  4
+    uint32_t outGridSize;         //  8   1, 2 or 4
+    uint32_t hintGridSize;        // 12   same value; unread with hints disabled
+    uint32_t mode;                // 16   1 = NV_OF_MODE_OPTICALFLOW
+    uint32_t perfLevel;           // 20   5 SLOW, 10 MEDIUM, 20 FAST
+    uint32_t enableExternalHints; // 24
+    uint32_t enableOutputCost;    // 28
+    void    *hPrivData;           // 32
+    uint32_t disparityRange;      // 40
+    uint32_t enableRoi;           // 44
+};
+
+struct NvOfExecuteInputParams
+{
+    void    *inputFrame;           //  0  the CURRENT frame
+    void    *referenceFrame;       //  8  the PREVIOUS frame
+    void    *externalHints;        // 16
+    uint32_t disableTemporalHints; // 24
+    uint32_t padding;              // 28
+    void    *hPrivData;            // 32
+    uint32_t padding2;             // 40
+    uint32_t numRois;              // 44
+    void    *roiData;              // 48
+};
+
+struct NvOfExecuteOutputParams { void *outputBuffer; void *outputCostBuffer; void *hPrivData; };
+
+// The same discipline as the PanelImGui asserts: a miscounted pad is a compile
+// error here rather than a call through the wrong offset at runtime.
+static_assert(sizeof(NvOfInitParams) == 48 && offsetof(NvOfInitParams, hPrivData) == 32,
+              "NvOfInitParams does not match the layout measured against the driver");
+static_assert(sizeof(NvOfExecuteInputParams) == 56 &&
+              offsetof(NvOfExecuteInputParams, numRois) == 44,
+              "NvOfExecuteInputParams does not match the layout measured against the driver");
+
+typedef NvOfStatus (__stdcall *PFN_OfaCreateInstance)(uint32_t, void *);
+typedef NvOfStatus (__stdcall *PFN_OfaCreateD3D11)(ID3D11Device *, ID3D11DeviceContext *, void **);
+typedef NvOfStatus (__stdcall *PFN_OfaInit)(void *, const NvOfInitParams *);
+typedef NvOfStatus (__stdcall *PFN_OfaRegister)(void *, ID3D11Resource *, void **);
+typedef NvOfStatus (__stdcall *PFN_OfaUnregister)(void *);
+typedef NvOfStatus (__stdcall *PFN_OfaExecute)(void *, const NvOfExecuteInputParams *,
+                                               NvOfExecuteOutputParams *);
+typedef NvOfStatus (__stdcall *PFN_OfaDestroy)(void *);
+typedef NvOfStatus (__stdcall *PFN_OfaLastError)(void *, char *, uint32_t *);
+
+static const char *OfaStatusName(NvOfStatus s)
+{
+    switch (s)
+    {
+    case 0:  return "SUCCESS";
+    case 1:  return "INVALID_PTR";
+    case 2:  return "INVALID_PARAM";
+    case 3:  return "INVALID_CALL";
+    case 4:  return "INVALID_VERSION";
+    case 5:  return "OUT_OF_MEMORY";
+    case 6:  return "NOT_INITIALIZED";
+    case 7:  return "UNSUPPORTED_FEATURE";
+    case 8:  return "GENERIC";
+    case 9:  return "OF_NOT_AVAILABLE";
+    case 10: return "UNSUPPORTED_DEVICE";
+    case 11: return "DEVICE_DOES_NOT_EXIST";
+    // A width or height the engine will not take comes back as 0x80004005,
+    // which is E_FAIL and not an NV_OF_STATUS at all. Every test below is
+    // != kOfaSuccess for exactly that reason, and this names the case rather
+    // than reporting it as an enum value nobody can look up.
+    case static_cast<NvOfStatus>(0x80004005): return "E_FAIL, not an NV_OF_STATUS";
+    default: return "a status this build has no name for";
+    }
+}
+
+// 5, 10 and 20 are NVOFA's own values; anything else was refused by the config
+// validator, so the default arm can only be reached if that check is changed.
+static const char *SynthPerfName(int p)
+{
+    return p == 5 ? "SLOW" : p == 10 ? "MEDIUM" : p == 20 ? "FAST" : "?";
+}
+
+struct SynthOfa
+{
+    bool    tried;      // the first open was attempted; a failed first open is never retried
+    bool    ready;      // dll, instance, session, textures, shaders all in hand
+    bool    stopped;    // gave up after being ready; no ReShade provider is substituted
+    bool    primed;     // src[prev] holds a real frame, so an execute is possible
+    bool    first_said;
+    HMODULE lib;
+    void   *slot[64];
+    void   *session;
+    UINT    w, h, grid;
+    int     perf;       // the NV_OF_PERF_LEVEL this session was opened with
+    DXGI_FORMAT back_fmt;               // the shape the session was opened for
+    // The device every texture below was created on, compared rather than
+    // assumed. A game that re-creates its D3D11 device -- ReShade answers that
+    // with a fresh effect runtime and this add-on keeps running -- would
+    // otherwise leave a CopyResource between two devices, which is undefined
+    // rather than an error. Held as a bare pointer and never dereferenced: the
+    // textures below hold their own references, so the address cannot be reused
+    // by a second device while this session exists, and the comparison is exact.
+    ID3D11Device *dev;
+    void   *reg_src[2], *reg_flow;      // registration handles
+    ID3D11Texture2D *copy, *src[2], *flow, *mv;
+    ID3D11ShaderResourceView  *copy_srv, *flow_srv;
+    ID3D11UnorderedAccessView *src_uav[2], *mv_uav;
+    ID3D11ComputeShader *luma_cs, *flow_cs;
+    int    cur;         // which of src[] this frame writes
+    int    fails;       // consecutive execute failures
+    bool   checked;     // the self-check has run for this shape
+    int    quiet;       // frames seen with no motion anywhere, for the self-check
+    UINT64 frames;
+};
+
+static SynthOfa g_ofa;
+
+// Each driver entry point gets its own guarded wrapper, for the reason the NGX
+// wrappers in dlss5-bridge.cpp were given theirs: these are undocumented
+// exports reached through signatures recovered from disassembly, and a wrong
+// guess has to land in the log rather than take the game down. Each is its own
+// function with no C++ objects, so __try is legal and no unwinding is needed.
+static NvOfStatus OfaSafeCreateInstance(PFN_OfaCreateInstance fn, uint32_t ver, void *slots)
+{
+    __try { return fn(ver, slots); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeCreateSession(PFN_OfaCreateD3D11 fn, ID3D11Device *d,
+                                       ID3D11DeviceContext *c, void **out)
+{
+    __try { return fn(d, c, out); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeInit(PFN_OfaInit fn, void *s, const NvOfInitParams *p)
+{
+    __try { return fn(s, p); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeRegister(PFN_OfaRegister fn, void *s, ID3D11Resource *r, void **out)
+{
+    __try { return fn(s, r, out); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeUnregister(PFN_OfaUnregister fn, void *h)
+{
+    __try { return fn(h); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeDestroy(PFN_OfaDestroy fn, void *s)
+{
+    __try { return fn(s); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+static NvOfStatus OfaSafeExecute(PFN_OfaExecute fn, void *s, const NvOfExecuteInputParams *in,
+                                 NvOfExecuteOutputParams *out)
+{
+    __try { return fn(s, in, out); }
+    __except (CaptureFault(GetExceptionInformation())) { return kOfaRaised; }
+}
+
+// The driver's own account of what it refused, which is what makes an nvOFInit
+// failure actionable: it names the offending field. Empty when the call has
+// nothing to say or is not safe to make.
+static void OfaLastError(char *dst, size_t cap)
+{
+    dst[0] = '\0';
+    if (g_ofa.session == nullptr || g_ofa.slot[8] == nullptr) return;
+    uint32_t n = static_cast<uint32_t>(cap);
+    auto fn = reinterpret_cast<PFN_OfaLastError>(g_ofa.slot[8]);
+    __try { fn(g_ofa.session, dst, &n); }
+    __except (CaptureFault(GetExceptionInformation())) { dst[0] = '\0'; }
+    // Nothing in the recovered signature promises a terminator, and every caller
+    // hands the result straight to a %s.
+    dst[cap - 1] = '\0';
+}
+
+// Unregister before release, on every path including a half-built open: the
+// driver holds these handles and releasing the texture under one is a use after
+// free inside the display driver rather than in this process.
+//
+// lib, slot and the two compiled shaders are deliberately left alone. They are
+// shape-independent, and recompiling two compute shaders on a resolution change
+// is a D3DCompile for nothing.
+static void OfaClose()
+{
+    auto unreg = reinterpret_cast<PFN_OfaUnregister>(g_ofa.slot[5]);
+    if (unreg != nullptr)
+    {
+        for (int i = 0; i < 2; ++i)
+            if (g_ofa.reg_src[i] != nullptr) OfaSafeUnregister(unreg, g_ofa.reg_src[i]);
+        if (g_ofa.reg_flow != nullptr) OfaSafeUnregister(unreg, g_ofa.reg_flow);
+    }
+    g_ofa.reg_src[0] = g_ofa.reg_src[1] = g_ofa.reg_flow = nullptr;
+
+    if (g_ofa.copy_srv != nullptr) { g_ofa.copy_srv->Release(); g_ofa.copy_srv = nullptr; }
+    if (g_ofa.flow_srv != nullptr) { g_ofa.flow_srv->Release(); g_ofa.flow_srv = nullptr; }
+    if (g_ofa.mv_uav   != nullptr) { g_ofa.mv_uav->Release();   g_ofa.mv_uav   = nullptr; }
+    for (int i = 0; i < 2; ++i)
+        if (g_ofa.src_uav[i] != nullptr) { g_ofa.src_uav[i]->Release(); g_ofa.src_uav[i] = nullptr; }
+
+    if (g_ofa.copy != nullptr) { g_ofa.copy->Release(); g_ofa.copy = nullptr; }
+    for (int i = 0; i < 2; ++i)
+        if (g_ofa.src[i] != nullptr) { g_ofa.src[i]->Release(); g_ofa.src[i] = nullptr; }
+    if (g_ofa.flow != nullptr) { g_ofa.flow->Release(); g_ofa.flow = nullptr; }
+    if (g_ofa.mv   != nullptr) { g_ofa.mv->Release();   g_ofa.mv   = nullptr; }
+
+    // The two compute shaders, which this function did not release. OfaOpen
+    // compiles a fresh pair on every shape change, so each change leaked one of
+    // each -- and a shader holds a reference on the D3D11 device it was compiled
+    // by, so the private device outlived the session that owned it and could not
+    // be reclaimed for the life of the process.
+    if (g_ofa.luma_cs != nullptr) { g_ofa.luma_cs->Release(); g_ofa.luma_cs = nullptr; }
+    if (g_ofa.flow_cs != nullptr) { g_ofa.flow_cs->Release(); g_ofa.flow_cs = nullptr; }
+
+    if (g_ofa.session != nullptr)
+    {
+        auto destroy = reinterpret_cast<PFN_OfaDestroy>(g_ofa.slot[7]);
+        if (destroy != nullptr) OfaSafeDestroy(destroy, g_ofa.session);
+        g_ofa.session = nullptr;
+    }
+
+    g_ofa.ready   = false;
+    g_ofa.primed  = false;
+    g_ofa.checked = false;
+    g_ofa.fails   = 0;
+    g_ofa.quiet   = 0;
+    g_ofa.cur     = 0;
+    g_ofa.dev     = nullptr;
+}
+
+// There is no teardown at DLL_PROCESS_DETACH, and that is deliberate rather than
+// an oversight: g_s12 and g_svk have none either, for the same reasons. Releasing
+// GPU objects from DllMain under the loader lock is a hazard, most games never
+// reach detach at all, and the process is exiting. OfaClose on a shape change is
+// the only teardown that exists.
+
+static bool OfaMakeShader(ID3D11Device *dev11, const char *src, const char *name,
+                          ID3D11ComputeShader **out)
+{
+    if (*out != nullptr) return true;
+
+    PFN_D3DCompile_ compile = LoadSystemD3DCompiler();
+    if (compile == nullptr) { Log("[synth] optical flow: d3dcompiler_47.dll is unavailable, so the flow "
+                                     "conversion shader cannot be built"); return false; }
+
+    ID3DBlob *code = nullptr, *err = nullptr;
+    HRESULT hr = compile(src, strlen(src), name, nullptr, nullptr, "main", "cs_5_0", 0, 0,
+                         &code, &err);
+    if (FAILED(hr) || code == nullptr)
+    {
+        Log("[synth] optical flow shader compile failed 0x%08X: %s", hr,
+            err != nullptr ? static_cast<const char *>(err->GetBufferPointer()) : "");
+        if (err != nullptr) err->Release();
+        return false;
+    }
+    if (err != nullptr) err->Release();
+
+    hr = dev11->CreateComputeShader(code->GetBufferPointer(), code->GetBufferSize(), nullptr, out);
+    code->Release();
+    if (FAILED(hr))
+    { Log("[synth] optical flow CreateComputeShader failed 0x%08X", hr); return false; }
+    return true;
+}
+
+// Grey rather than colour: the estimator matches on structure and a single
+// channel is what it reduces to anyway. Reinhard rather than saturate, because
+// an R16G16B16A16_FLOAT back buffer clips every highlight to white under
+// saturate and the estimator then has nothing to lock onto in exactly the bright
+// regions that carry the most detail. Reinhard is monotone, so nothing it
+// matches on is reordered.
+// Split in two so the middle line can be chosen from the back buffer format.
+//
+// The engine's input surface is B8G8R8A8_UNORM -- eight bits of luma. The
+// Reinhard curve l/(l+1) was written for a float back buffer that can exceed
+// 1.0, where compressing the range is the only way to get it into eight bits at
+// all. Applied to a UNORM buffer, whose luma is already in [0,1], it maps that
+// range onto [0,0.5] and hands the estimator seven bits instead of eight, for
+// nothing. Red Dead Redemption 2 and Baldur's Gate 3 both present
+// R10G10B10A2_UNORM, so both were paying it, and so is every 8-bit SDR title.
+static const char kOfaLumaHead[] =
+    "Texture2D<float4>   src : register(t0);\n"
+    "RWTexture2D<float4> dst : register(u0);\n"
+    "[numthreads(8,8,1)]\n"
+    "void main(uint3 id : SV_DispatchThreadID)\n"
+    "{\n"
+    "    uint w, h; dst.GetDimensions(w, h);\n"
+    "    if (id.x >= w || id.y >= h) return;\n"
+    "    float3 c = src[id.xy].rgb;\n"
+    "    float  l = dot(c, float3(0.2126, 0.7152, 0.0722));\n";
+static const char kOfaLumaTonemap[] = "    l = l / (l + 1.0);\n";
+static const char kOfaLumaClamp[]   = "    l = saturate(l);\n";
+static const char kOfaLumaTail[] =
+    "    dst[id.xy] = float4(l, l, l, 1.0);\n"
+    "}\n";
+
+// Three things here are load-bearing and each one is a measurement.
+//
+//  1/32   the output is S10.5 fixed point, so the stored value is pixels x 32.
+//  /(w,h) the contract stores UV and MV.Scale multiplies by (W,H) to get back to
+//         pixels, so the round trip is exact.
+//  no sign flip: with inputFrame = this frame and referenceFrame = the previous
+//         one, the vector already points from the current pixel back to where
+//         that content was, which is verbatim the DLSS definition. Measured over
+//         1,166,400 vectors, 100% within 0.5 px, both axes.
+//
+// The reconstruction filter is NEAREST, not bilinear, and that is the one place
+// this departs from what the transport note first sketched. The disocclusion
+// band is 12-16 px wide in pixels at every grid, and the values inside it
+// correspond to no surface in the scene. Bilinear across that band manufactures
+// more such values and spreads it wider; nearest quantises but never invents a
+// vector no cell measured. Where the field is smooth it varies far more slowly
+// than one grid cell and both filters land inside the 0.1 px noise floor.
+//
+// id.x * fw / w is the exact integer divide whenever fw*grid == w, which is
+// every resolution in practice; the min keeps the sample inside the texture at
+// the ones where it is not.
+static const char kOfaFlowSrc[] =
+    "Texture2D<int2>     flow : register(t0);\n"
+    "RWTexture2D<float2> dst  : register(u0);\n"
+    "[numthreads(8,8,1)]\n"
+    "void main(uint3 id : SV_DispatchThreadID)\n"
+    "{\n"
+    "    uint w, h, fw, fh;\n"
+    "    dst.GetDimensions(w, h);\n"
+    "    flow.GetDimensions(fw, fh);\n"
+    "    if (id.x >= w || id.y >= h) return;\n"
+    "    uint2 c = min(uint2(id.x * fw / w, id.y * fh / h), uint2(fw - 1, fh - 1));\n"
+    "    dst[id.xy] = float2(flow[c]) * (1.0 / 32.0) / float2(w, h);\n"
+    "}\n";
+
+static ID3D11Texture2D *OfaMakeTexture(ID3D11Device *dev11, UINT w, UINT h, DXGI_FORMAT fmt,
+                                       UINT bind, const char *what)
+{
+    D3D11_TEXTURE2D_DESC td = {};
+    td.Width = w; td.Height = h; td.MipLevels = 1; td.ArraySize = 1;
+    td.Format = fmt; td.SampleDesc.Count = 1;
+    td.Usage = D3D11_USAGE_DEFAULT; td.BindFlags = bind;
+
+    ID3D11Texture2D *t = nullptr;
+    const HRESULT hr = dev11->CreateTexture2D(&td, nullptr, &t);
+    if (FAILED(hr))
+    {
+        Log("[synth] optical flow: could not create the %ux%u %s texture for %s: 0x%08X",
+            w, h, FormatName(fmt), what, hr);
+        return nullptr;
+    }
+    return t;
+}
+// The private D3D11 device the Vulkan transport runs the engine on, or null when
+// there is none. Declared here because OfaOpen has to name which device it opened
+// on and g_ovk is defined far below it.
+static ID3D11Device *SynthOfaVkDevice();
+
+
+static bool OfaOpen(ID3D11Device *dev11, ID3D11DeviceContext *ctx, UINT w, UINT h,
+                    DXGI_FORMAT back_fmt)
+{
+    // Before anything that can fail, exactly as Synth12Open and SynthVkOpen set
+    // theirs: a first open that failed is never retried.
+    g_ofa.tried = true;
+    g_ofa.w = w; g_ofa.h = h; g_ofa.back_fmt = back_fmt; g_ofa.dev = dev11;
+    g_ofa.grid = static_cast<UINT>(g_cfg.ofa_grid);
+    // Validated where it is divided by rather than only where it is set. Every
+    // caller checks for zero before getting here, and that is exactly the kind of
+    // agreement that a later caller breaks silently: the two divisions below turn a
+    // zero into an integer divide fault, which takes the game with it rather than
+    // refusing. The config parser accepts 0 as "engine off", so this value reaches
+    // the function from a user's file and from a panel click.
+    if (g_ofa.grid == 0)
+    {
+        Log("[synth] optical flow: ofa_grid is 0, which switches the engine off, so "
+            "the session is not opened. The motion vectors come from a ReShade effect.");
+        return false;
+    }
+
+    if (g_ofa.lib == nullptr)
+    {
+        g_ofa.lib = LoadLibraryW(L"nvofapi64.dll");
+        if (g_ofa.lib == nullptr)
+        {
+            Log("[synth] optical flow: nvofapi64.dll is not loadable in this process. It is "
+                "installed with the display driver, so this means no NVIDIA driver here "
+                "rather than a driver too old.");
+            return false;
+        }
+        auto create = reinterpret_cast<PFN_OfaCreateInstance>(
+            GetProcAddress(g_ofa.lib, "NvOFAPICreateInstanceD3D11"));
+        if (create == nullptr)
+        {
+            Log("[synth] optical flow: nvofapi64.dll exports no NvOFAPICreateInstanceD3D11.");
+            return false;
+        }
+        // 0x20 is the public 2.0 layout, which is the one the structs above were
+        // written to and confirmed against on this machine. The D3D11 entry was
+        // measured to accept 0x10 through 0x50.
+        const NvOfStatus r = OfaSafeCreateInstance(create, 0x20, g_ofa.slot);
+        if (r != kOfaSuccess)
+        {
+            Log("[synth] optical flow: this driver refused API version 0x20 with status %ld "
+                "(%s). The D3D11 entry accepts 0x10 through 0x50 on the driver this was "
+                "measured against.", r, OfaStatusName(r));
+            memset(g_ofa.slot, 0, sizeof(g_ofa.slot));
+            return false;
+        }
+    }
+
+    // Asked once, before a texture exists. BGRA8 typed UAV store is not in
+    // D3D11's guaranteed set, and without it the conversion writes nothing and
+    // the engine is handed a blank frame -- which looks like bad flow rather
+    // than like a missing feature.
+    {
+        D3D11_FEATURE_DATA_FORMAT_SUPPORT2 f2 = {};
+        f2.InFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+        if (FAILED(dev11->CheckFeatureSupport(D3D11_FEATURE_FORMAT_SUPPORT2, &f2, sizeof(f2))) ||
+            (f2.OutFormatSupport2 & D3D11_FORMAT_SUPPORT2_UAV_TYPED_STORE) == 0)
+        {
+            Log("[synth] optical flow: this device cannot store to a B8G8R8A8_UNORM "
+                "unordered access view, so the colour frame cannot be converted into the "
+                "only 4-channel format the flow engine accepts.");
+            return false;
+        }
+    }
+
+    {
+        const bool hdrish = SynthFormatCanExceedOne(back_fmt);
+        char luma[sizeof(kOfaLumaHead) + sizeof(kOfaLumaTonemap) + sizeof(kOfaLumaTail) + 8];
+        _snprintf_s(luma, sizeof(luma), _TRUNCATE, "%s%s%s", kOfaLumaHead,
+                    hdrish ? kOfaLumaTonemap : kOfaLumaClamp, kOfaLumaTail);
+        if (!OfaMakeShader(dev11, luma, "ofaluma", &g_ofa.luma_cs)) return false;
+        Log("[synth] optical flow: luma is %s, because the back buffer is %s.",
+            hdrish ? "tone-mapped with l/(l+1) before the 8-bit conversion"
+                   : "clamped rather than tone-mapped, so all eight bits of the "
+                     "engine's input carry signal",
+            FormatName(back_fmt));
+    }
+    if (!OfaMakeShader(dev11, kOfaFlowSrc, "ofaflow", &g_ofa.flow_cs)) return false;
+
+    const UINT fw = (w + g_ofa.grid - 1) / g_ofa.grid;
+    const UINT fh = (h + g_ofa.grid - 1) / g_ofa.grid;
+
+    // The back buffer is not guaranteed to carry BIND_SHADER_RESOURCE -- a DXGI
+    // swapchain only promises a render target view -- so a compute shader cannot
+    // read it directly. CopyResource into a texture we created with the same
+    // format always works.
+    g_ofa.copy = OfaMakeTexture(dev11, w, h, TypedFormat(back_fmt),
+                                D3D11_BIND_SHADER_RESOURCE, "the colour copy");
+    // BGRA8 because the engine's legal input list is BGRA8, NV12 and R8_UNORM,
+    // and Skyrim SE presents R8G8B8A8_UNORM. SHADER_RESOURCE alongside the UAV
+    // because that is the binding the registration was proven with in the
+    // harness, and it costs nothing.
+    for (int i = 0; i < 2; ++i)
+        g_ofa.src[i] = OfaMakeTexture(dev11, w, h, DXGI_FORMAT_B8G8R8A8_UNORM,
+                                      D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE,
+                                      i == 0 ? "the current frame" : "the previous frame");
+    g_ofa.flow = OfaMakeTexture(dev11, fw, fh, DXGI_FORMAT_R16G16_SINT,
+                                D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS,
+                                "the flow field");
+    // Exactly the shape SynthArmRefusal already demands of a motion vector
+    // texture, so the gate needs no new rule. That is the whole point of
+    // converting here rather than handing NGX the engine's own output.
+    g_ofa.mv = OfaMakeTexture(dev11, w, h, DXGI_FORMAT_R16G16_FLOAT,
+                              D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE,
+                              "the motion vectors");
+    if (g_ofa.copy == nullptr || g_ofa.src[0] == nullptr || g_ofa.src[1] == nullptr ||
+        g_ofa.flow == nullptr || g_ofa.mv == nullptr)
+    { OfaClose(); return false; }
+
+    HRESULT hr = dev11->CreateShaderResourceView(g_ofa.copy, nullptr, &g_ofa.copy_srv);
+    if (SUCCEEDED(hr)) hr = dev11->CreateShaderResourceView(g_ofa.flow, nullptr, &g_ofa.flow_srv);
+    for (int i = 0; i < 2 && SUCCEEDED(hr); ++i)
+        hr = dev11->CreateUnorderedAccessView(g_ofa.src[i], nullptr, &g_ofa.src_uav[i]);
+    if (SUCCEEDED(hr)) hr = dev11->CreateUnorderedAccessView(g_ofa.mv, nullptr, &g_ofa.mv_uav);
+    if (FAILED(hr))
+    {
+        Log("[synth] optical flow: a view over one of the four textures could not be "
+            "created: 0x%08X", hr);
+        OfaClose();
+        return false;
+    }
+
+    LogVideoMemory("before opening the optical flow session");
+
+    auto create_ses = reinterpret_cast<PFN_OfaCreateD3D11>(g_ofa.slot[0]);
+    NvOfStatus r = OfaSafeCreateSession(create_ses, dev11, ctx, &g_ofa.session);
+    if (r != kOfaSuccess || g_ofa.session == nullptr)
+    {
+        // The real case this covers: nvofapi64.dll is present because an NVIDIA
+        // GPU is installed, while the game renders on the iGPU.
+        Log("[synth] optical flow: the driver will not open a session on this D3D11 device: "
+            "status %ld (%s). This is what a game rendering on an adapter other than the "
+            "NVIDIA one looks like, which happens on a hybrid laptop.", r, OfaStatusName(r));
+        g_ofa.session = nullptr;
+        OfaClose();
+        return false;
+    }
+
+    NvOfInitParams ip;
+    memset(&ip, 0, sizeof(ip));
+    ip.width = w; ip.height = h;
+    ip.outGridSize = g_ofa.grid;
+    ip.hintGridSize = g_ofa.grid;      // unread with hints disabled; set to match
+    ip.mode = 1;                       // NV_OF_MODE_OPTICALFLOW
+    // From the config, validated there to 5, 10 or 20 -- NVOFA's own
+    // NV_OF_PERF_LEVEL values, so a number quoted in a report reads against
+    // NVIDIA's own table. FAST by default because it is the only level that
+    // fits a frame at 4K: measured at 3840x1600 grid 2, FAST costs 1.6 ms
+    // where MEDIUM costs 6.2 and SLOW 11.5. The slower levels estimate more
+    // accurately, which is the knob to reach for when fine detail drifts.
+    ip.perfLevel = static_cast<uint32_t>(g_cfg.ofa_perf);
+    g_ofa.perf   = g_cfg.ofa_perf;
+    auto init = reinterpret_cast<PFN_OfaInit>(g_ofa.slot[1]);
+    r = OfaSafeInit(init, g_ofa.session, &ip);
+    if (r != kOfaSuccess)
+    {
+        // Tested against SUCCESS rather than switched on the enum, because a
+        // width or height error comes back as E_FAIL, which is not one.
+        char msg[512];
+        OfaLastError(msg, sizeof(msg));
+        Log("[synth] optical flow: nvOFInit refused %ux%u at grid %u with 0x%08lX (%s). %s",
+            w, h, g_ofa.grid, static_cast<unsigned long>(r), OfaStatusName(r), msg);
+        if (r == 5)   // NV_OF_ERR_OUT_OF_MEMORY
+            Log("[synth]   Grid 2 needs about 109 MB driver-side at 3840x1600; grid 4 needs "
+                "about 63 MB. Try ofa_grid=4 in dlss5-bridge.cfg.");
+        OfaClose();
+        return false;
+    }
+
+    auto reg = reinterpret_cast<PFN_OfaRegister>(g_ofa.slot[4]);
+    NvOfStatus r0 = OfaSafeRegister(reg, g_ofa.session, g_ofa.src[0],  &g_ofa.reg_src[0]);
+    NvOfStatus r1 = OfaSafeRegister(reg, g_ofa.session, g_ofa.src[1],  &g_ofa.reg_src[1]);
+    NvOfStatus r2 = OfaSafeRegister(reg, g_ofa.session, g_ofa.flow,    &g_ofa.reg_flow);
+    if (r0 != kOfaSuccess || r1 != kOfaSuccess || r2 != kOfaSuccess ||
+        g_ofa.reg_src[0] == nullptr || g_ofa.reg_src[1] == nullptr || g_ofa.reg_flow == nullptr)
+    {
+        char msg[512];
+        OfaLastError(msg, sizeof(msg));
+        Log("[synth] optical flow: registering the three buffers was refused (%ld, %ld, %ld). %s",
+            r0, r1, r2, msg);
+        OfaClose();
+        return false;
+    }
+
+    g_ofa.ready   = true;
+    g_ofa.stopped = false;
+
+    // Which device, said rather than assumed. This named "the game's own D3D11
+    // device" unconditionally, and on the Vulkan transport that is false: the
+    // game has no D3D11 device there and the session opens on a private one this
+    // add-on created. The two are told apart by the pointer, because g_ovk.dev is
+    // non-null only when this file made it.
+    Log("[synth] optical flow: nvofapi64.dll loaded, instance at API 0x20, session open on "
+        "%s. Grid %u, perf %s, flow %ux%u R16G16_SINT -> %ux%u "
+        "R16G16_FLOAT. This is kSynthMv[0] and the three ReShade motion-vector names are "
+        "not consulted while it is running.",
+        (SynthOfaVkDevice() != nullptr && SynthOfaVkDevice() == dev11)
+            ? "a private D3D11 device this add-on created, because the game is on Vulkan"
+            : "the game's own D3D11 device",
+        g_ofa.grid, SynthPerfName(g_ofa.perf), fw, fh, w, h);
+    Log("[synth] optical flow conversion shaders ready (cs_5_0)");
+    LogVideoMemory("after opening the optical flow session");
+    return true;
+}
+
+// One compute dispatch, with the game's own compute bindings saved and put back
+// exactly as BridgeBlitDepth does it. This runs on the immediate context in the
+// middle of the game's frame. Two separate calls rather than one block spanning
+// both dispatches, because nvOFExecute runs between them on the same context.
+static void OfaDispatch(ID3D11DeviceContext *ctx, ID3D11ComputeShader *cs,
+                        ID3D11ShaderResourceView *srv, ID3D11UnorderedAccessView *uav,
+                        UINT w, UINT h)
+{
+    ID3D11ComputeShader       *old_cs  = nullptr;
+    ID3D11ShaderResourceView  *old_srv = nullptr;
+    ID3D11UnorderedAccessView *old_uav = nullptr;
+    ctx->CSGetShader(&old_cs, nullptr, nullptr);
+    ctx->CSGetShaderResources(0, 1, &old_srv);
+    ctx->CSGetUnorderedAccessViews(0, 1, &old_uav);
+
+    UINT keep = static_cast<UINT>(-1);
+    ctx->CSSetShader(cs, nullptr, 0);
+    ctx->CSSetShaderResources(0, 1, &srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &uav, &keep);
+    ctx->Dispatch((w + 7) / 8, (h + 7) / 8, 1);
+
+    ID3D11ShaderResourceView  *no_srv = nullptr;
+    ID3D11UnorderedAccessView *no_uav = nullptr;
+    ctx->CSSetShaderResources(0, 1, &no_srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &no_uav, &keep);
+
+    ctx->CSSetShader(old_cs, nullptr, 0);
+    ctx->CSSetShaderResources(0, 1, &old_srv);
+    ctx->CSSetUnorderedAccessViews(0, 1, &old_uav, &keep);
+    if (old_cs  != nullptr) old_cs->Release();
+    if (old_srv != nullptr) old_srv->Release();
+    if (old_uav != nullptr) old_uav->Release();
+}
+
+// The one runnable check this stage leaves behind, and it ships enabled. It
+// checks the arithmetic rather than the plumbing -- the plumbing announces its
+// own failures above -- by recomputing what the conversion shader should have
+// written from the flow texture the DRIVER actually filled, not from anything
+// this add-on assumed.
+//
+// It runs once per shape, and only on a frame whose flow field contains a
+// non-zero vector: a frame with no motion proves nothing, because 0 == 0 passes
+// a shader that has the scale wrong, the grid ratio wrong, or is not running at
+// all.
+static void OfaSelfCheck(ID3D11Device *dev11, ID3D11DeviceContext *ctx)
+{
+    // The first attempt is taken immediately, because the frame right after
+    // priming is the one most likely to have motion in it. Every attempt after
+    // that waits for a multiple of sixteen: each one stages and maps about 30 MB
+    // and blocks until the GPU has caught up, and a game that opens on a static
+    // menu would otherwise take that stall on a hundred frames in a row with
+    // nothing in the log to attribute the hitch to.
+    if (g_ofa.quiet > 0 && (g_ofa.frames & 15) != 0) return;
+
+    // Three assertions off GetDesc alone, which cost nothing and catch a
+    // mis-sized texture before a single texel is read.
+    D3D11_TEXTURE2D_DESC fd = {}, md = {};
+    g_ofa.flow->GetDesc(&fd);
+    g_ofa.mv->GetDesc(&md);
+    const UINT want_fw = (g_ofa.w + g_ofa.grid - 1) / g_ofa.grid;
+    const UINT want_fh = (g_ofa.h + g_ofa.grid - 1) / g_ofa.grid;
+    if (fd.Width != want_fw || fd.Height != want_fh || fd.Format != DXGI_FORMAT_R16G16_SINT ||
+        md.Width != g_ofa.w || md.Height != g_ofa.h || md.Format != DXGI_FORMAT_R16G16_FLOAT ||
+        g_ofa.flow == reinterpret_cast<ID3D11Texture2D *>(g_ofa.mv))
+    {
+        g_ofa.checked = true;
+        Log("[synth] DEFECT: the optical flow textures are not the shape this build claims. "
+            "Flow is %ux%u fmt %u, expected %ux%u R16G16_SINT; motion vectors are %ux%u "
+            "fmt %u, expected %ux%u R16G16_FLOAT.",
+            fd.Width, fd.Height, fd.Format, want_fw, want_fh,
+            md.Width, md.Height, md.Format, g_ofa.w, g_ofa.h);
+        return;
+    }
+
+    D3D11_TEXTURE2D_DESC sd = fd;
+    sd.Usage = D3D11_USAGE_STAGING; sd.BindFlags = 0;
+    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ; sd.MiscFlags = 0;
+    ID3D11Texture2D *fs = nullptr, *ms = nullptr;
+    if (FAILED(dev11->CreateTexture2D(&sd, nullptr, &fs))) return;
+    sd = md;
+    sd.Usage = D3D11_USAGE_STAGING; sd.BindFlags = 0;
+    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ; sd.MiscFlags = 0;
+    if (FAILED(dev11->CreateTexture2D(&sd, nullptr, &ms))) { fs->Release(); return; }
+
+    ctx->CopyResource(fs, g_ofa.flow);
+    ctx->CopyResource(ms, g_ofa.mv);
+
+    D3D11_MAPPED_SUBRESOURCE fm = {}, mm = {};
+    if (FAILED(ctx->Map(fs, 0, D3D11_MAP_READ, 0, &fm)) ||
+        FAILED(ctx->Map(ms, 0, D3D11_MAP_READ, 0, &mm)))
+    { fs->Release(); ms->Release(); return; }
+
+    int   sampled = 0, bad = 0, nonzero = 0;
+    float worst = 0.0f;
+    // How far past its own tolerance the worst offender was, so a real defect
+    // report carries a number that is not confusable with rounding.
+    float worst_over = 0.0f;
+    int   bx = 0, by = 0, bfx = 0, bfy = 0;
+    float bex = 0.0f, bey = 0.0f, bax = 0.0f, bay = 0.0f;
+
+    for (UINT cy = 0; cy < fd.Height; cy += 16)
+    {
+        const int16_t *frow = reinterpret_cast<const int16_t *>(
+            static_cast<const unsigned char *>(fm.pData) + static_cast<size_t>(cy) * fm.RowPitch);
+        const UINT py = cy * g_ofa.grid + g_ofa.grid / 2;
+        if (py >= md.Height) continue;
+        const unsigned short *mrow = reinterpret_cast<const unsigned short *>(
+            static_cast<const unsigned char *>(mm.pData) + static_cast<size_t>(py) * mm.RowPitch);
+
+        for (UINT cx = 0; cx < fd.Width; cx += 16)
+        {
+            const UINT px = cx * g_ofa.grid + g_ofa.grid / 2;
+            if (px >= md.Width) continue;
+
+            const int fx = frow[cx * 2], fy = frow[cx * 2 + 1];
+            if (fx != 0 || fy != 0) ++nonzero;
+
+            // expected: what the shader should have written, computed from the
+            // flow texture the driver actually filled.
+            const float ex = static_cast<float>(fx) * (1.0f / 32.0f) / static_cast<float>(g_ofa.w);
+            const float ey = static_cast<float>(fy) * (1.0f / 32.0f) / static_cast<float>(g_ofa.h);
+            const float ax = DirectX::PackedVector::XMConvertHalfToFloat(mrow[px * 2]);
+            const float ay = DirectX::PackedVector::XMConvertHalfToFloat(mrow[px * 2 + 1]);
+
+            // Compared in PIXELS, which is the unit a reader of the log can act
+            // on. The tolerance has to scale, and the flat 0.02 px it used to be
+            // was below the storage precision:
+            //
+            // The texture holds the vector in UV, in half-float. Half has a
+            // 10-bit mantissa, so the step between representable values at
+            // magnitude m is about m * 2^-10 -- and multiplied back by the axis
+            // that is (m * axis) * 2^-10, which is a PIXEL magnitude times 2^-10.
+            // At 36.5 px one step is 0.0293 px, larger than the 0.02 px this
+            // compared against. Measured in Red Dead Redemption 2 on 2026-09-01:
+            // expected -36.500 px, stored -36.475 px, a difference of 0.025 px
+            // that is less than one representable step -- and the log reported a
+            // DEFECT, told the user the image would smear, and blamed this
+            // add-on for arithmetic that was exact.
+            //
+            // The comment that justified 0.02 said rounding was "about 5e-4 px at
+            // these magnitudes", which is the relative precision without the
+            // multiplication back into pixels.
+            //
+            // 2^-9 rather than 2^-10 leaves one step of headroom, and still
+            // catches every way this can be wrong: a missing /32 errs by 32x, a
+            // wrong grid ratio picks another cell's vector entirely, a Y flip
+            // errs by twice the value, and a shader that never ran leaves zeros.
+            const float dx = fabsf(ax - ex) * static_cast<float>(g_ofa.w);
+            const float dy = fabsf(ay - ey) * static_cast<float>(g_ofa.h);
+            const float d  = dx > dy ? dx : dy;
+            const float mx = fabsf(ex) * static_cast<float>(g_ofa.w);
+            const float my = fabsf(ey) * static_cast<float>(g_ofa.h);
+            const float tol = 0.02f + (mx > my ? mx : my) * (1.0f / 512.0f);
+            ++sampled;
+            if (d > worst)
+            {
+                worst = d;
+                bx = static_cast<int>(cx); by = static_cast<int>(cy);
+                bfx = fx; bfy = fy;
+                bex = ex * static_cast<float>(g_ofa.w); bey = ey * static_cast<float>(g_ofa.h);
+                bax = ax * static_cast<float>(g_ofa.w); bay = ay * static_cast<float>(g_ofa.h);
+            }
+            if (d > tol) ++bad;
+            if (d > tol && d > worst_over) worst_over = d - tol;
+        }
+    }
+
+    ctx->Unmap(fs, 0);
+    ctx->Unmap(ms, 0);
+    fs->Release();
+    ms->Release();
+
+    if (nonzero == 0)
+    {
+        // A still frame disproves nothing, so this is not a verdict. Same voice
+        // as the depth report's "unverified".
+        // Eight attempts, one immediately and the rest sixteen frames apart, so
+        // the window is still about 120 frames wide -- the count is of what was
+        // actually looked at, because that is the number a reader can check.
+        if (++g_ofa.quiet >= 8)
+        {
+            g_ofa.checked = true;
+            Log("[synth] optical flow self-check: 8 checks spread over the first 120 or so "
+                "frames found no non-zero vector anywhere, so the conversion could not be "
+                "checked. Nothing was disproved.");
+        }
+        return;
+    }
+
+    g_ofa.checked = true;
+    if (bad == 0)
+        Log("[synth] optical flow self-check: %d cells sampled, flow %ux%u R16G16_SINT -> "
+            "%ux%u R16G16_FLOAT, worst disagreement %.3f px. The conversion, the 1/32 scale "
+            "and the grid mapping are what this build claims they are.",
+            sampled, fd.Width, fd.Height, g_ofa.w, g_ofa.h, worst);
+    else
+        // Delivery continues. This is a defect report about this add-on, and
+        // refusing to deliver would hide the numbers a report needs. The text
+        // names the likely cause by construction, because it prints both numbers
+        // in pixels rather than a verdict: a factor of exactly 32 is the missing
+        // scale.
+        Log("[synth] DEFECT: the optical flow conversion disagrees with its own input at "
+            "cell (%d,%d): flow (%+d,%+d) is %+.3f,%+.3f px, and the motion vector texture "
+            "holds %+.3f,%+.3f px. %d of %d cells sampled disagree by more than their own "
+            "storage precision, the worst by %.3f px beyond it. The image will smear; this "
+            "is a defect in this add-on and not in the estimator.",
+            bx, by, bfx, bfy, bex, bey, bax, bay, bad, sampled, worst_over);
+}
+
+// One frame. Returns true when out holds a motion vector texture NGX may read.
+//
+// The copy, both dispatches and the execute are timed together rather than the
+// execute alone, because all of it is new cost -- and because nvOFExecute blocks
+// the calling thread, which here is ReShade's present thread, so this is CPU
+// time inside the game's frame rather than merely GPU time. The one-off session
+// open is outside the bracket; see the note at the QueryPerformanceCounter.
+// The body, over a colour texture and a device the caller supplies. Two callers:
+// OfaFrame below, which is the D3D11 game's own device and its back buffer, and
+// SynthOfaVkFrame, which is a private D3D11 device and the D3D12 shared texture
+// the Vulkan frame was already copied into. Extracted rather than duplicated --
+// everything here except where the two pointers come from is the same code, and
+// a second copy of an nvOFExecute call with its own failure counting is exactly
+// the thing that drifts.
+//
+// dev11, ctx and src are BORROWED. This function releases none of them.
+static bool OfaFrameOn(ID3D11Device *dev11, ID3D11DeviceContext *ctx,
+                       ID3D11Texture2D *src, DXGI_FORMAT src_fmt,
+                       UINT w, UINT h, SynthBound *out)
+{
+    SynthBound blank = {};
+    *out = blank;
+    if (dev11 == nullptr || ctx == nullptr || src == nullptr) return false;
+
+    LARGE_INTEGER t0, t1;
+    bool delivered  = false;
+    bool want_check = false;
+
+    // A resolution change, a format change, or an ofa_grid or ofa_perf edit
+    // rebuilds the session in place. tried is not consulted here: it governs the
+    // first open only, and a failed re-open is recorded by stopped instead.
+    //
+    // perf was absent from this test until the panel gained a control for it.
+    // NV_OF_PERF_LEVEL is only read at nvOFInit, so editing ofa_perf mid-session
+    // was accepted by the parser, passed the validator, was reported as a config
+    // change -- and estimated at the old level for the rest of the session, with
+    // the log still printing the old name. One clause, and the teardown below is
+    // the one ofa_grid already proved.
+    if (g_ofa.ready && (g_ofa.w != w || g_ofa.h != h || g_ofa.back_fmt != src_fmt ||
+                        g_ofa.dev != dev11 ||
+                        g_ofa.grid != static_cast<UINT>(g_cfg.ofa_grid) ||
+                        g_ofa.perf != g_cfg.ofa_perf))
+    {
+        Log("[synth] optical flow: the back buffer became %ux%u %s at grid %d perf %s on "
+            "device %p, so the session is rebuilt.", w, h, FormatName(src_fmt),
+            g_cfg.ofa_grid, SynthPerfName(g_cfg.ofa_perf),
+            static_cast<void *>(dev11));
+        OfaClose();
+        if (!OfaOpen(dev11, ctx, w, h, src_fmt))
+        {
+            Log("[synth] optical flow: the session could not be rebuilt for the new size, "
+                "so this stops.");
+            g_ofa.stopped = true;
+        }
+    }
+    else if (!g_ofa.ready && !g_ofa.tried)
+    {
+        OfaOpen(dev11, ctx, w, h, src_fmt);
+    }
+
+    // Nothing below ran, so nothing below is charged for. Counting a frame here
+    // would put an "optical flow" clause on the timing line of a session that
+    // fell back to a ReShade provider and never ran the engine at all, which is
+    // the one thing that line exists to be able to deny.
+    if (!g_ofa.ready) return false;
+
+    // Started here rather than at the top of the function, so a one-off session
+    // open -- two shader compiles, five textures and an nvOFInit -- is not
+    // averaged into the per-frame figure it would otherwise dominate. What is
+    // measured from here is the copy, both dispatches and the execute: all of
+    // it new cost, and all of it on ReShade's present thread.
+    QueryPerformanceCounter(&t0);
+
+    // The colour frame, converted into the only 4-channel format the engine
+    // takes. One copy and one dispatch; the copy is ~0.03 ms of bandwidth at
+    // 3840x1600 against 1.6 ms of execute, which is why there is one path here
+    // and not a second that tries an SRV over the back buffer first.
+    ctx->CopyResource(g_ofa.copy, src);
+    OfaDispatch(ctx, g_ofa.luma_cs, g_ofa.copy_srv, g_ofa.src_uav[g_ofa.cur], w, h);
+
+    if (!g_ofa.primed)
+    {
+        g_ofa.primed = true;
+        g_ofa.cur ^= 1;
+        if (!g_ofa.first_said)
+        {
+            g_ofa.first_said = true;
+            Log("[synth] optical flow: the first frame has no previous frame to compare "
+                "against, so nothing is delivered on it. Flow starts on the next one.");
+        }
+        goto done;
+    }
+
+    {
+        NvOfExecuteInputParams  in;
+        NvOfExecuteOutputParams eo;
+        memset(&in, 0, sizeof(in));
+        memset(&eo, 0, sizeof(eo));
+        in.inputFrame           = g_ofa.reg_src[g_ofa.cur];       // the CURRENT frame
+        in.referenceFrame       = g_ofa.reg_src[g_ofa.cur ^ 1];   // the PREVIOUS frame
+        in.disableTemporalHints = 1;   // what every measurement for this was taken with
+        eo.outputBuffer         = g_ofa.reg_flow;
+
+        auto exec = reinterpret_cast<PFN_OfaExecute>(g_ofa.slot[6]);
+        const NvOfStatus r = OfaSafeExecute(exec, g_ofa.session, &in, &eo);
+        ++g_ofa.frames;
+
+        if (r == kOfaRaised)
+        {
+            // Calling back into a component that faulted is what turned a
+            // disabled add-on into a killed process on Final Fantasy VII Remake.
+            Log("[synth] optical flow: nvOFExecute raised an exception, so this stops here. "
+                "The game keeps rendering on its own.");
+            g_ofa.ready   = false;
+            g_ofa.stopped = true;
+            goto done;
+        }
+        if (r != kOfaSuccess)
+        {
+            if (g_ofa.fails == 0 || g_ofa.fails == 2)
+            {
+                char msg[512];
+                OfaLastError(msg, sizeof(msg));
+                Log("[synth] optical flow: execute %llu refused with status %ld (%s). %s",
+                    g_ofa.frames, r, OfaStatusName(r), msg);
+            }
+            // This frame is not delivered and the game's own frame goes to screen
+            // untouched.
+            //
+            // The slot still advances, and it has to. The luma dispatch above has
+            // ALREADY written this frame into src[cur], destroying what was there --
+            // so the frame this comment used to call "the previous frame, kept" is
+            // gone whatever happens next. Leaving cur alone made the following
+            // frame overwrite src[cur] again and compare against a reference two
+            // frames old, reporting two frames of motion as one. Advancing it
+            // costs the one comparison that was already lost and puts the next
+            // pair back in step.
+            //
+            // Never fired in the sessions measured so far -- Red Dead Redemption 2
+            // delivered 1800 frames out of 1800 with no refusal -- so this is a
+            // defect found by reading rather than one seen.
+            g_ofa.cur ^= 1;
+            if (++g_ofa.fails >= 3)
+            {
+                Log("[synth] optical flow: three consecutive failures, so this stops. No "
+                    "ReShade motion-vector texture is substituted: the temporal history "
+                    "DLSS has accumulated was built from these vectors and swapping the "
+                    "estimator under it is the defect this path was rebuilt to avoid.");
+                g_ofa.ready   = false;
+                g_ofa.stopped = true;
+            }
+            goto done;
+        }
+
+        g_ofa.fails = 0;
+        OfaDispatch(ctx, g_ofa.flow_cs, g_ofa.flow_srv, g_ofa.mv_uav, w, h);
+        // Wanted, not run: the check stages and maps about 30 MB and blocks
+        // until the GPU catches up, and inside the bracket below that stall
+        // would be charged to the per-frame flow figure -- the same error the
+        // bracket was moved down the function to avoid for the session open.
+        want_check = !g_ofa.checked;
+
+        // No AddRef, and for the reason written over the Get in SynthParams:
+        // SynthOfa owns mv for the life of the shape and nothing downstream
+        // releases what it takes out of the contract.
+        out->res     = reshade::api::resource { reinterpret_cast<uintptr_t>(g_ofa.mv) };
+        out->tex11   = nullptr;
+        out->w       = w;
+        out->h       = h;
+        out->fmt     = DXGI_FORMAT_R16G16_FLOAT;
+        out->samples = 1;
+        out->usage   = 0;
+
+        // Advanced HERE and not at the exit, and the difference is not
+        // housekeeping. On a refused execute this is deliberately skipped, so
+        // the next frame overwrites src[cur] and keeps src[cur^1] -- which is
+        // the input of the last execute that SUCCEEDED, and therefore the last
+        // frame DLSS was actually given. A refused frame is not delivered, so
+        // DLSS's history is still at that same frame, and the vector it needs is
+        // the one spanning the whole gap rather than the last hop of it.
+        // Advancing unconditionally would hand a two-frame gap a one-frame
+        // vector and under-reproject the history by exactly one frame, which is
+        // the smear this path was rebuilt to remove, reintroduced on the
+        // recovery frame.
+        g_ofa.cur ^= 1;
+        delivered = true;
+    }
+
+done:
+    QueryPerformanceCounter(&t1);
+    g_bridge.ofa_ticks += (t1.QuadPart - t0.QuadPart);
+    ++g_bridge.ofa_frames;
+
+    // Outside the bracket on purpose. It runs at most a handful of times in a
+    // session and it blocks on the GPU; charging it to the per-frame figure
+    // would make the first report of a working session read three times its
+    // real cost.
+    if (want_check) OfaSelfCheck(dev11, ctx);
+
+    // TimingTick is reached only through BridgeFrame, so a session that runs the
+    // engine every frame and never delivers one would spend this and never
+    // report it -- and a blocking call in the game's present thread that no line
+    // in the log accounts for is precisely what this measurement exists to make
+    // impossible. Said here when 600 flow frames have gone by with not one
+    // delivered frame to carry the figure.
+    if (g_bridge.ofa_frames >= 600 && g_bridge.timed_frames == 0)
+    {
+        // Asked for here rather than read off g_bridge.qpf: that field is filled
+        // by TimingTick, and TimingTick not having run is the whole condition
+        // this branch is testing for.
+        LARGE_INTEGER qpf;
+        QueryPerformanceFrequency(&qpf);
+        Log("[synth] optical flow: %.2f ms/frame over %llu frames, and not one of them "
+            "reached the bridge's own frame path -- so nothing else in this log accounts "
+            "for that time. It is spent on ReShade's present thread.",
+            1000.0 * double(g_bridge.ofa_ticks) / double(qpf.QuadPart)
+                   / double(g_bridge.ofa_frames),
+            g_bridge.ofa_frames);
+        g_bridge.ofa_ticks  = 0;
+        g_bridge.ofa_frames = 0;
+    }
+
+    return delivered;
+}
+
+// The D3D11 game's own device and its own back buffer, resolved off the runtime.
+// Everything this does beyond that is in OfaFrameOn.
+static bool OfaFrame(reshade::api::effect_runtime *rt, reshade::api::command_list *cmd,
+                     reshade::api::resource_view rtv, UINT w, UINT h, SynthBound *out)
+{
+    SynthBound blank = {};
+    *out = blank;
+
+    auto *ctx = reinterpret_cast<ID3D11DeviceContext *>(
+        static_cast<uintptr_t>(cmd->get_native()));
+    if (ctx == nullptr) return false;
+
+    SynthBound back = {};
+    SynthResolveView(rt->get_device(), static_cast<uint32_t>(reshade::api::device_api::d3d11),
+                     rtv, &back);
+    if (back.tex11 == nullptr) return false;
+    if (back.w != w || back.h != h) { back.tex11->Release(); return false; }
+
+    ID3D11Device *dev11 = nullptr;
+    ctx->GetDevice(&dev11);
+    if (dev11 == nullptr) { back.tex11->Release(); return false; }
+
+    const bool delivered = OfaFrameOn(dev11, ctx, back.tex11, back.fmt, w, h, out);
+
+    dev11->Release();
+    back.tex11->Release();
+    return delivered;
+}

--- a/src/feed_perf.h
+++ b/src/feed_perf.h
@@ -1,0 +1,137 @@
+// feed_perf.h -- append FPS/CPU + knobs to dlss5-perf.jsonl next to the add-on.
+// oneclick reads this for history + nearest-neighbour expected FPS.
+//
+// Include after CfgPath / g_cfg / g_feed_ofa_cfg / g_feed_lightstab_cfg / g_feed_auto exist.
+
+#pragma once
+
+#include <ctime>
+
+#ifndef FEED_PERF_MAX_LINES
+#define FEED_PERF_MAX_LINES 1500
+#endif
+#ifndef FEED_PERF_PERIOD_MS
+#define FEED_PERF_PERIOD_MS 2000
+#endif
+
+static ULONGLONG g_feed_perf_last_write = 0;
+static int       g_feed_perf_pending = 0; // set on knob dirty / CfgSave
+
+static void FeedPerfPath(char *out)
+{
+    GetModuleFileNameA(g_self, out, MAX_PATH);
+    if (char *s = strrchr(out, '\\'))
+        strcpy_s(s + 1, MAX_PATH - (s + 1 - out), "dlss5-perf.jsonl");
+}
+
+static float FeedPerfCpuPercent()
+{
+    // Process CPU% over a short window using GetProcessTimes vs wall clock.
+    static ULONGLONG last_wall = 0;
+    static ULONGLONG last_kernel = 0, last_user = 0;
+    FILETIME ct, et, kt, ut;
+    if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut))
+        return -1.f;
+    ULARGE_INTEGER k, u;
+    k.LowPart = kt.dwLowDateTime; k.HighPart = kt.dwHighDateTime;
+    u.LowPart = ut.dwLowDateTime; u.HighPart = ut.dwHighDateTime;
+    const ULONGLONG now = GetTickCount64();
+    float pct = -1.f;
+    if (last_wall != 0 && now > last_wall)
+    {
+        const ULONGLONG dwall = (now - last_wall) * 10000ull; // ms → 100ns
+        const ULONGLONG dcpu = (k.QuadPart - last_kernel) + (u.QuadPart - last_user);
+        if (dwall > 0)
+            pct = 100.f * (float)dcpu / (float)dwall;
+        if (pct < 0.f) pct = 0.f;
+        if (pct > 100.f) pct = 100.f;
+    }
+    last_wall = now;
+    last_kernel = k.QuadPart;
+    last_user = u.QuadPart;
+    return pct;
+}
+
+static void FeedPerfTrim(const char *path)
+{
+    FILE *f = nullptr;
+    if (fopen_s(&f, path, "rb") != 0 || f == nullptr) return;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    if (sz < 0 || sz < 256 * 1024) { fclose(f); return; } // small enough
+    fseek(f, 0, SEEK_SET);
+    // Count lines; if over cap, keep the last FEED_PERF_MAX_LINES.
+    char *buf = (char *)malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return; }
+    size_t nread = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[nread] = 0;
+    int lines = 0;
+    for (size_t i = 0; i < nread; ++i) if (buf[i] == '\n') ++lines;
+    if (lines <= FEED_PERF_MAX_LINES) { free(buf); return; }
+    int skip = lines - FEED_PERF_MAX_LINES;
+    char *p = buf;
+    while (skip > 0 && *p)
+    {
+        if (*p == '\n') --skip;
+        ++p;
+    }
+    FILE *w = nullptr;
+    if (fopen_s(&w, path, "wb") == 0 && w)
+    {
+        fputs(p, w);
+        fclose(w);
+    }
+    free(buf);
+}
+
+// fps / frame_ms from recent present interval (caller supplies).
+static void FeedPerfAppend(float fps, float frame_ms)
+{
+    char path[MAX_PATH];
+    FeedPerfPath(path);
+    FILE *f = nullptr;
+    if (fopen_s(&f, path, "ab") != 0 || f == nullptr) return;
+    const ULONGLONG ts = (ULONGLONG)time(nullptr);
+    const float cpu = FeedPerfCpuPercent();
+    const char *ap = g_feed_auto.name[0] ? g_feed_auto.name : "";
+    fprintf(f,
+        "{\"ts\":%llu,\"fps\":%.2f,\"frame_ms\":%.3f,\"cpu_pct\":%.1f,"
+        "\"work_resolution\":%d,\"ofa_enabled\":%d,\"ofa_grid\":%d,\"ofa_perf\":%d,"
+        "\"reset_mode\":%d,\"light_stab\":%d,\"evaluate_stride\":%d,\"auto_profile\":\"%s\"}\n",
+        (unsigned long long)ts,
+        fps, frame_ms, cpu,
+        g_cfg.work_resolution,
+        g_feed_ofa_cfg.enabled ? 1 : 0,
+        g_feed_ofa_cfg.grid,
+        g_feed_ofa_cfg.perf,
+        g_cfg.reset_mode,
+        g_feed_lightstab_cfg.enabled ? 1 : 0,
+        g_feed_auto.evaluate_stride > 0 ? g_feed_auto.evaluate_stride : 1,
+        ap);
+    fclose(f);
+    static int writes = 0;
+    if ((++writes % 32) == 0)
+        FeedPerfTrim(path);
+}
+
+static void FeedPerfMarkDirty()
+{
+    g_feed_perf_pending = 1;
+}
+
+// Call once per frame from TimingTick with the present interval in ms.
+static void FeedPerfTick(double interval_ms)
+{
+    if (interval_ms < 1.0 || interval_ms > 250.0) return;
+    const ULONGLONG now = GetTickCount64();
+    const bool due = g_feed_perf_pending ||
+                     (g_feed_perf_last_write == 0) ||
+                     (now - g_feed_perf_last_write >= FEED_PERF_PERIOD_MS);
+    if (!due) return;
+    g_feed_perf_pending = 0;
+    g_feed_perf_last_write = now;
+    const float frame_ms = (float)interval_ms;
+    const float fps = frame_ms > 0.1f ? (1000.f / frame_ms) : 0.f;
+    FeedPerfAppend(fps, frame_ms);
+}

--- a/src/feed_quality.h
+++ b/src/feed_quality.h
@@ -1,0 +1,119 @@
+// feed_quality.h -- quality presets (Auto/Low/Medium/High) mirrored from oneclick.
+// Include after g_cfg / g_feed_ofa_cfg / g_feed_velocity_cfg and CfgSave() exist.
+
+#pragma once
+
+enum FeedQualityChoice
+{
+    FeedQuality_Auto = 0,
+    FeedQuality_Low = 1,
+    FeedQuality_Medium = 2,
+    FeedQuality_High = 3,
+    FeedQuality_Custom = 4,
+};
+
+static FeedQualityChoice g_feed_quality = FeedQuality_Auto;
+static bool g_feed_quality_customized = false;
+
+static const char *FeedQualityName(FeedQualityChoice q)
+{
+    switch (q)
+    {
+    case FeedQuality_Auto:   return "Auto";
+    case FeedQuality_Low:    return "Low";
+    case FeedQuality_Medium: return "Medium";
+    case FeedQuality_High:   return "High";
+    default:                 return "Custom";
+    }
+}
+
+static const char *FeedQualityCfgName(FeedQualityChoice q)
+{
+    switch (q)
+    {
+    case FeedQuality_Auto:   return "auto";
+    case FeedQuality_Low:    return "low";
+    case FeedQuality_Medium: return "medium";
+    case FeedQuality_High:   return "high";
+    default:                 return "custom";
+    }
+}
+
+// Apply preset to live cfg (OFA + work resolution). FX uniforms are set at Install.
+static void FeedQualityApply(FeedQualityChoice q, bool ofa_capable_d3d11)
+{
+    g_feed_quality_customized = false;
+    g_feed_quality = q;
+    switch (q)
+    {
+    case FeedQuality_Low:
+        g_feed_ofa_cfg.enabled = 0;
+        g_feed_ofa_cfg.grid = 2;
+        g_feed_ofa_cfg.perf = 10;
+        g_cfg.work_resolution = 70;
+        g_cfg.work_upscale = 1;
+        g_cfg.work_sharpness = 0.35f;
+        g_feed_velocity_cfg.enabled = 0;
+        g_cfg.reset_mode = FeedReset_Adaptive;
+        g_cfg.reset_every = 0;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Adaptive;
+        g_feed_lightstab_cfg.enabled = 1;
+        g_feed_lightstab_cfg.strength = 0.35f;
+        g_feed_lightstab_cfg.max_delta = 0.06f;
+        break;
+    case FeedQuality_Medium:
+        g_feed_ofa_cfg.enabled = ofa_capable_d3d11 ? 1 : 0;
+        g_feed_ofa_cfg.grid = 2;
+        g_feed_ofa_cfg.perf = 10;
+        g_cfg.work_resolution = 85;
+        g_cfg.work_upscale = 1;
+        g_cfg.work_sharpness = 0.30f;
+        g_feed_velocity_cfg.enabled = 1; // hunt on; bind when found
+        g_cfg.reset_mode = FeedReset_Adaptive;
+        g_cfg.reset_every = 0;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Adaptive;
+        g_feed_lightstab_cfg.enabled = 0;
+        break;
+    case FeedQuality_High:
+        g_feed_ofa_cfg.enabled = ofa_capable_d3d11 ? 1 : 0;
+        g_feed_ofa_cfg.grid = 1;
+        g_feed_ofa_cfg.perf = 10;
+        g_cfg.work_resolution = 100;
+        g_cfg.work_upscale = 0;
+        g_cfg.work_sharpness = 0.30f;
+        g_feed_velocity_cfg.enabled = 1;
+        g_cfg.reset_mode = FeedReset_Adaptive;
+        g_cfg.reset_every = 0;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Adaptive;
+        g_feed_lightstab_cfg.enabled = 0;
+        break;
+    case FeedQuality_Auto:
+    default:
+        if (ofa_capable_d3d11)
+        {
+            g_feed_ofa_cfg.enabled = 1;
+            g_feed_ofa_cfg.grid = 2;
+            g_feed_ofa_cfg.perf = 10;
+            g_cfg.work_resolution = 100;
+            g_cfg.work_upscale = 0;
+            g_cfg.work_sharpness = 0.30f;
+        }
+        else
+        {
+            g_feed_ofa_cfg.enabled = 0;
+            g_feed_ofa_cfg.grid = 2;
+            g_feed_ofa_cfg.perf = 10;
+            g_cfg.work_resolution = 85;
+            g_cfg.work_upscale = 1;
+            g_cfg.work_sharpness = 0.30f;
+        }
+        g_feed_velocity_cfg.enabled = 1;
+        g_cfg.reset_mode = FeedReset_Adaptive;
+        g_cfg.reset_every = 0;
+        g_feed_adapt_cfg.reset_mode = FeedReset_Adaptive;
+        g_feed_lightstab_cfg.enabled = 0;
+        g_feed_quality = FeedQuality_Auto;
+        break;
+    }
+    g_work_resolution_ui = g_cfg.work_resolution;
+}

--- a/src/feed_velocity.h
+++ b/src/feed_velocity.h
@@ -1,0 +1,798 @@
+// feed_velocity.h -- engine velocity RT hunter (PPOM-style) + bind into DLSS MV.
+//
+// Include from dlss5-feed.cpp AFTER Log() is defined and <reshade.hpp> is available.
+// Tracks D3D11 float RTs during bind_render_targets + draw, scores candidates,
+// copies the chosen one into a private RG16F for NGX (velocity > OFA > Lumenite).
+
+#pragma once
+
+#include <cstring>
+#include <cctype>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <d3d11.h>
+
+// Log() must already be defined by the including translation unit (dlss5-feed.cpp).
+
+enum FeedVelocityDecode
+{
+    FeedVelDecode_Auto = 0,      // heuristic: RawPixels if magnitudes look like px, else DeltaUV
+    FeedVelDecode_RawPixels = 1, // already pixel deltas (DLSS contract)
+    FeedVelDecode_DeltaUV = 2,   // UV deltas → multiply by resolution
+    FeedVelDecode_UEPacked = 3,  // UE-ish packed → scale * resolution
+};
+
+struct FeedVelocityCfg
+{
+    int   enabled;       // engine_velocity=
+    int   cand;          // -1 = auto best score, else index
+    int   decode;        // FeedVelocityDecode
+    float scale;         // extra multiplier after decode
+};
+
+static FeedVelocityCfg g_feed_velocity_cfg = { 1, -1, FeedVelDecode_Auto, 1.0f };
+
+enum { kFeedVelMaxCands = 32 };
+
+struct FeedVelocityCand
+{
+    uint64_t handle;
+    uint32_t width, height;
+    reshade::api::format fmt;
+    char     name[96];
+    bool     name_hit;
+    int      score;
+    int      draws_frame;
+    int      draws_total;
+    bool     saw_with_depth;
+};
+
+struct FeedVelocityState
+{
+    reshade::api::effect_texture_variable var;
+    char name[128];
+    bool detected;
+    bool bound_ok;
+    int  last_w, last_h;
+    char bound_src[32];
+    char overlay_line[256];
+
+    FeedVelocityCand cands[kFeedVelMaxCands];
+    int cand_count;
+    int chosen_cand = -1; // resolved index this frame, or -1
+
+    // Currently bound RTs (updated on bind_render_targets)
+    uint64_t bound_rt[8];
+    uint32_t bound_rt_count;
+    bool     bound_has_dsv;
+
+    UINT bb_w, bb_h;
+    uint64_t frame_id;
+
+    // Private full-res RG16F we hand to DLSS (owned)
+    ID3D11Texture2D *out_tex;
+    ID3D11RenderTargetView *out_rtv;
+    UINT out_w, out_h;
+
+    // Lazy fullscreen blit (half-res upsample / RGBA→RG)
+    ID3D11VertexShader *blit_vs;
+    ID3D11PixelShader  *blit_ps;
+    ID3D11SamplerState *blit_smp;
+    ID3D11Buffer       *blit_cb;
+    bool blit_ready;
+
+    // Applied into evaluate mv_scale for this frame (decode)
+    float apply_scale_x, apply_scale_y;
+    bool  scale_override;
+};
+
+static FeedVelocityState g_feed_velocity = {};
+// Ensure chosen_cand starts as -1 (aggregate init zeroes it otherwise).
+struct FeedVelocityInitOnce { FeedVelocityInitOnce() { g_feed_velocity.chosen_cand = -1; g_feed_velocity_cfg.cand = -1; } };
+static FeedVelocityInitOnce g_feed_velocity_init_once;
+
+static const GUID kFeedVelDebugNameGuid =
+    { 0x429b8c22, 0x9188, 0x4b0c, { 0x87, 0x42, 0xac, 0xb0, 0xbf, 0x85, 0xc2, 0x00 } };
+
+static bool FeedVelocityNameHit(const char *name)
+{
+    if (name == nullptr || name[0] == '\0') return false;
+    char lower[256];
+    size_t n = 0;
+    for (; name[n] != '\0' && n + 1 < sizeof(lower); ++n)
+        lower[n] = static_cast<char>(tolower(static_cast<unsigned char>(name[n])));
+    lower[n] = '\0';
+    if (strstr(lower, "dlss5") != nullptr) return false;
+    if (strstr(lower, "lumenite") != nullptr) return false;
+    // Broad engine-agnostic name hits (UE / Unity / custom / console ports).
+    return strstr(lower, "velocity") != nullptr ||
+           strstr(lower, "motionblur") != nullptr ||
+           strstr(lower, "motion_blur") != nullptr ||
+           strstr(lower, "motion_vectors") != nullptr ||
+           strstr(lower, "motionvectors") != nullptr ||
+           strstr(lower, "motionvector") != nullptr ||
+           strstr(lower, "velbuffer") != nullptr ||
+           strstr(lower, "gvelocity") != nullptr ||
+           strstr(lower, "scenevelocity") != nullptr ||
+           strstr(lower, "worldvelocity") != nullptr ||
+           strstr(lower, "screenvelocity") != nullptr ||
+           strstr(lower, "objectmotion") != nullptr ||
+           strstr(lower, "pixelvelocity") != nullptr ||
+           strstr(lower, "cameramotion") != nullptr ||
+           strstr(lower, "gbuffer_velocity") != nullptr ||
+           strstr(lower, "gbuffervelocity") != nullptr ||
+           strstr(lower, "mvbuffer") != nullptr ||
+           strstr(lower, "vec_velocity") != nullptr ||
+           strstr(lower, "rt_velocity") != nullptr ||
+           strstr(lower, "velocityrt") != nullptr ||
+           (strstr(lower, "vel") != nullptr && strstr(lower, "buffer") != nullptr) ||
+           (strstr(lower, "motion") != nullptr && strstr(lower, "vector") != nullptr);
+}
+
+static bool FeedVelocityFmtCandidate(reshade::api::format f)
+{
+    using reshade::api::format;
+    // Prefer true velocity layouts (RG*); RGBA16F is common for packed GBuffers but often wrong.
+    return f == format::r16g16_float ||
+           f == format::r16g16_typeless ||
+           f == format::r16g16b16a16_float ||
+           f == format::r16g16b16a16_typeless ||
+           f == format::r32g32_float ||
+           f == format::r32g32_typeless;
+}
+
+static DXGI_FORMAT FeedVelocityDxgiTyped(reshade::api::format f)
+{
+    using reshade::api::format;
+    switch (f)
+    {
+    case format::r16g16_float:
+    case format::r16g16_typeless: return DXGI_FORMAT_R16G16_FLOAT;
+    case format::r32g32_float:
+    case format::r32g32_typeless: return DXGI_FORMAT_R32G32_FLOAT;
+    case format::r16g16b16a16_float:
+    case format::r16g16b16a16_typeless: return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    default: return DXGI_FORMAT_UNKNOWN;
+    }
+}
+
+static const char *FeedVelocityFmtLabel(reshade::api::format f)
+{
+    using reshade::api::format;
+    switch (f)
+    {
+    case format::r16g16_float:
+    case format::r16g16_typeless: return "RG16F";
+    case format::r32g32_float:
+    case format::r32g32_typeless: return "RG32F";
+    case format::r16g16b16a16_float:
+    case format::r16g16b16a16_typeless: return "RGBA16F";
+    default: return "?";
+    }
+}
+
+static bool FeedVelocityFmtIsRg(reshade::api::format f)
+{
+    using reshade::api::format;
+    return f == format::r16g16_float || f == format::r16g16_typeless ||
+           f == format::r32g32_float || f == format::r32g32_typeless;
+}
+
+static bool FeedVelocityFmtIsRgba16(reshade::api::format f)
+{
+    using reshade::api::format;
+    return f == format::r16g16b16a16_float || f == format::r16g16b16a16_typeless;
+}
+
+static void FeedVelocityReadDebugName(ID3D11DeviceChild *obj, char *out, size_t out_n)
+{
+    out[0] = '\0';
+    if (obj == nullptr || out_n < 2) return;
+    UINT sz = 0;
+    if (FAILED(obj->GetPrivateData(kFeedVelDebugNameGuid, &sz, nullptr)) || sz == 0 || sz > 512)
+        return;
+    char buf[512];
+    if (sz > sizeof(buf)) sz = sizeof(buf);
+    if (FAILED(obj->GetPrivateData(kFeedVelDebugNameGuid, &sz, buf))) return;
+    if (sz > 0 && buf[sz - 1] == '\0')
+        _snprintf_s(out, out_n, _TRUNCATE, "%s", buf);
+    else
+    {
+        if (sz >= out_n) sz = (UINT)(out_n - 1);
+        memcpy(out, buf, sz);
+        out[sz] = '\0';
+    }
+}
+
+static void FeedVelocityReleaseBlit()
+{
+    if (g_feed_velocity.blit_vs) { g_feed_velocity.blit_vs->Release(); g_feed_velocity.blit_vs = nullptr; }
+    if (g_feed_velocity.blit_ps) { g_feed_velocity.blit_ps->Release(); g_feed_velocity.blit_ps = nullptr; }
+    if (g_feed_velocity.blit_smp) { g_feed_velocity.blit_smp->Release(); g_feed_velocity.blit_smp = nullptr; }
+    if (g_feed_velocity.blit_cb) { g_feed_velocity.blit_cb->Release(); g_feed_velocity.blit_cb = nullptr; }
+    g_feed_velocity.blit_ready = false;
+}
+
+static void FeedVelocityReleaseOut()
+{
+    if (g_feed_velocity.out_rtv) { g_feed_velocity.out_rtv->Release(); g_feed_velocity.out_rtv = nullptr; }
+    if (g_feed_velocity.out_tex) { g_feed_velocity.out_tex->Release(); g_feed_velocity.out_tex = nullptr; }
+    g_feed_velocity.out_w = g_feed_velocity.out_h = 0;
+}
+
+static bool FeedVelocityEnsureBlit(ID3D11Device *dev)
+{
+    if (g_feed_velocity.blit_ready) return true;
+    if (dev == nullptr) return false;
+
+    typedef HRESULT (WINAPI *pD3DCompile)(LPCVOID, SIZE_T, LPCSTR, const D3D_SHADER_MACRO *,
+                                          ID3DInclude *, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob **, ID3DBlob **);
+    HMODULE m = LoadLibraryW(L"d3dcompiler_47.dll");
+    auto compile = m != nullptr ? reinterpret_cast<pD3DCompile>(GetProcAddress(m, "D3DCompile")) : nullptr;
+    if (compile == nullptr) { Log("[feed] velocity blit: d3dcompiler_47.dll unavailable"); return false; }
+
+    // Sample .xy from any float texture; uv_scale packs into CB (unused for sample; kept for future).
+    static const char kSrc[] =
+        "Texture2D src_tex : register(t0);\n"
+        "SamplerState smp : register(s0);\n"
+        "cbuffer CB : register(b0) { float2 uv_scale; float2 pad; };\n"
+        "struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };\n"
+        "VSOut vs(uint id : SV_VertexID) { VSOut o; float2 uv = float2((id << 1) & 2, id & 2);\n"
+        "  o.uv = uv; o.pos = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1); return o; }\n"
+        "float2 ps(VSOut i) : SV_Target { return src_tex.SampleLevel(smp, i.uv, 0).xy; }\n";
+
+    ID3DBlob *vs = nullptr, *ps = nullptr, *err = nullptr;
+    HRESULT hr = compile(kSrc, sizeof(kSrc) - 1, "velblit", nullptr, nullptr, "vs", "vs_5_0", 0, 0, &vs, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] velocity blit VS failed 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        return false;
+    }
+    if (err) { err->Release(); err = nullptr; }
+    hr = compile(kSrc, sizeof(kSrc) - 1, "velblit", nullptr, nullptr, "ps", "ps_5_0", 0, 0, &ps, &err);
+    if (FAILED(hr))
+    {
+        Log("[feed] velocity blit PS failed 0x%08X: %s", hr, err ? (const char *)err->GetBufferPointer() : "");
+        if (err) err->Release();
+        if (vs) vs->Release();
+        return false;
+    }
+    if (err) err->Release();
+
+    hr = dev->CreateVertexShader(vs->GetBufferPointer(), vs->GetBufferSize(), nullptr, &g_feed_velocity.blit_vs);
+    if (SUCCEEDED(hr))
+        hr = dev->CreatePixelShader(ps->GetBufferPointer(), ps->GetBufferSize(), nullptr, &g_feed_velocity.blit_ps);
+    vs->Release();
+    ps->Release();
+    if (FAILED(hr)) { Log("[feed] velocity blit shader create failed 0x%08X", hr); FeedVelocityReleaseBlit(); return false; }
+
+    D3D11_SAMPLER_DESC sd = {};
+    sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+    sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    if (FAILED(dev->CreateSamplerState(&sd, &g_feed_velocity.blit_smp)))
+    { FeedVelocityReleaseBlit(); return false; }
+
+    D3D11_BUFFER_DESC cbd = {};
+    cbd.ByteWidth = 16;
+    cbd.Usage = D3D11_USAGE_DYNAMIC;
+    cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    if (FAILED(dev->CreateBuffer(&cbd, nullptr, &g_feed_velocity.blit_cb)))
+    { FeedVelocityReleaseBlit(); return false; }
+
+    g_feed_velocity.blit_ready = true;
+    Log("[feed] velocity blit shaders ready (upsample / RGBA→RG)");
+    return true;
+}
+
+static bool FeedVelocityEnsureOut(ID3D11Device *dev, UINT w, UINT h)
+{
+    if (g_feed_velocity.out_tex && g_feed_velocity.out_w == w && g_feed_velocity.out_h == h &&
+        g_feed_velocity.out_rtv)
+        return true;
+    FeedVelocityReleaseOut();
+    D3D11_TEXTURE2D_DESC d = {};
+    d.Width = w; d.Height = h; d.MipLevels = 1; d.ArraySize = 1;
+    d.Format = DXGI_FORMAT_R16G16_FLOAT;
+    d.SampleDesc.Count = 1;
+    d.Usage = D3D11_USAGE_DEFAULT;
+    d.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+    if (FAILED(dev->CreateTexture2D(&d, nullptr, &g_feed_velocity.out_tex)) || !g_feed_velocity.out_tex)
+        return false;
+    if (FAILED(dev->CreateRenderTargetView(g_feed_velocity.out_tex, nullptr, &g_feed_velocity.out_rtv)) ||
+        !g_feed_velocity.out_rtv)
+    {
+        FeedVelocityReleaseOut();
+        return false;
+    }
+    g_feed_velocity.out_w = w;
+    g_feed_velocity.out_h = h;
+    return true;
+}
+
+// Blit src → private RG16F out (handles size mismatch + RGBA/RG32 → .xy).
+static bool FeedVelocityBlitSrc(ID3D11Device *dev, ID3D11DeviceContext *ctx, ID3D11Texture2D *src,
+                                DXGI_FORMAT srv_fmt)
+{
+    if (!FeedVelocityEnsureBlit(dev) || g_feed_velocity.out_rtv == nullptr || src == nullptr)
+        return false;
+
+    D3D11_SHADER_RESOURCE_VIEW_DESC sv = {};
+    sv.Format = srv_fmt;
+    sv.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+    sv.Texture2D.MipLevels = 1;
+    ID3D11ShaderResourceView *srv = nullptr;
+    if (FAILED(dev->CreateShaderResourceView(src, &sv, &srv)) || !srv)
+        return false;
+
+    // Minimal state: save nothing — FeedFrame11 already owns the immediate context between
+    // ReShade draws; restore RT/VS/PS/topology after.
+    ID3D11RenderTargetView *prev_rtv = nullptr;
+    ID3D11DepthStencilView *prev_dsv = nullptr;
+    ctx->OMGetRenderTargets(1, &prev_rtv, &prev_dsv);
+
+    D3D11_VIEWPORT vp = {};
+    vp.Width = (float)g_feed_velocity.out_w;
+    vp.Height = (float)g_feed_velocity.out_h;
+    vp.MaxDepth = 1.0f;
+    ctx->RSSetViewports(1, &vp);
+    ctx->OMSetRenderTargets(1, &g_feed_velocity.out_rtv, nullptr);
+    ctx->IASetInputLayout(nullptr);
+    ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ctx->VSSetShader(g_feed_velocity.blit_vs, nullptr, 0);
+    ctx->PSSetShader(g_feed_velocity.blit_ps, nullptr, 0);
+    ctx->PSSetShaderResources(0, 1, &srv);
+    ctx->PSSetSamplers(0, 1, &g_feed_velocity.blit_smp);
+    if (g_feed_velocity.blit_cb)
+    {
+        D3D11_MAPPED_SUBRESOURCE mapped = {};
+        if (SUCCEEDED(ctx->Map(g_feed_velocity.blit_cb, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))
+        {
+            float *f = (float *)mapped.pData;
+            f[0] = 1.f; f[1] = 1.f; f[2] = 0.f; f[3] = 0.f;
+            ctx->Unmap(g_feed_velocity.blit_cb, 0);
+        }
+        ctx->PSSetConstantBuffers(0, 1, &g_feed_velocity.blit_cb);
+    }
+    ctx->Draw(3, 0);
+
+    ID3D11ShaderResourceView *null_srv = nullptr;
+    ctx->PSSetShaderResources(0, 1, &null_srv);
+    ctx->OMSetRenderTargets(1, &prev_rtv, prev_dsv);
+    if (prev_rtv) prev_rtv->Release();
+    if (prev_dsv) prev_dsv->Release();
+    srv->Release();
+    return true;
+}
+
+static int FeedVelocityFindCand(uint64_t handle)
+{
+    for (int i = 0; i < g_feed_velocity.cand_count; ++i)
+        if (g_feed_velocity.cands[i].handle == handle) return i;
+    return -1;
+}
+
+static void FeedVelocityUpsert(reshade::api::device *device, reshade::api::resource res)
+{
+    if (device == nullptr || res.handle == 0) return;
+    const reshade::api::resource_desc desc = device->get_resource_desc(res);
+    if (desc.type != reshade::api::resource_type::texture_2d) return;
+    if (desc.texture.depth_or_layers != 1) return;
+    if (!FeedVelocityFmtCandidate(desc.texture.format)) return;
+    if (desc.texture.width < 64 || desc.texture.height < 64) return;
+    if (g_feed_velocity.bb_w != 0 && desc.texture.width * 2 < g_feed_velocity.bb_w) return; // < ~50%
+
+    char name[96] = {};
+    if (device->get_api() == reshade::api::device_api::d3d11)
+        FeedVelocityReadDebugName(reinterpret_cast<ID3D11DeviceChild *>(res.handle), name, sizeof(name));
+    if (FeedVelocityNameHit(name) == false && name[0] &&
+        (strstr(name, "DLSS5") != nullptr || strstr(name, "dlss5") != nullptr))
+        return;
+
+    const bool name_hit = FeedVelocityNameHit(name);
+    int idx = FeedVelocityFindCand(res.handle);
+    if (idx < 0)
+    {
+        if (g_feed_velocity.cand_count >= kFeedVelMaxCands)
+        {
+            // Drop lowest-score slot
+            int worst = 0;
+            for (int i = 1; i < g_feed_velocity.cand_count; ++i)
+                if (g_feed_velocity.cands[i].score < g_feed_velocity.cands[worst].score) worst = i;
+            if (g_feed_velocity.cands[worst].score > 5) return;
+            idx = worst;
+        }
+        else
+            idx = g_feed_velocity.cand_count++;
+        FeedVelocityCand &c = g_feed_velocity.cands[idx];
+        memset(&c, 0, sizeof(c));
+        c.handle = res.handle;
+        c.width = desc.texture.width;
+        c.height = desc.texture.height;
+        c.fmt = desc.texture.format;
+        if (name[0]) _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "%s", name);
+        else _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "RT %s %ux%u",
+                         FeedVelocityFmtLabel(c.fmt), c.width, c.height);
+        c.name_hit = name_hit;
+    }
+    else
+    {
+        FeedVelocityCand &c = g_feed_velocity.cands[idx];
+        c.width = desc.texture.width;
+        c.height = desc.texture.height;
+        c.fmt = desc.texture.format;
+        if (name_hit) { c.name_hit = true; if (name[0]) _snprintf_s(c.name, sizeof(c.name), _TRUNCATE, "%s", name); }
+    }
+}
+
+static void FeedVelocityRescore(FeedVelocityCand &c)
+{
+    int s = 0;
+    if (c.name_hit) s += 220;
+    // True velocity buffers are almost always RG16F/RG32F. Unnamed RGBA16F full-res
+    // is frequently a lighting/GBuffer RT that ME wrongly latched — score it down hard.
+    if (FeedVelocityFmtIsRg(c.fmt))
+        s += (c.fmt == reshade::api::format::r16g16_float ||
+              c.fmt == reshade::api::format::r16g16_typeless) ? 120 : 90;
+    else if (FeedVelocityFmtIsRgba16(c.fmt))
+        s += c.name_hit ? 35 : 5;
+    else
+        s += 0;
+
+    if (g_feed_velocity.bb_w != 0 && c.width == g_feed_velocity.bb_w && c.height == g_feed_velocity.bb_h)
+        s += FeedVelocityFmtIsRg(c.fmt) ? 110 : (c.name_hit ? 60 : 15);
+    else if (g_feed_velocity.bb_w != 0 && c.width * 2 == g_feed_velocity.bb_w && c.height * 2 == g_feed_velocity.bb_h)
+        s += 45; // half-res common for UE velocity
+    else if (g_feed_velocity.bb_w != 0 && c.width >= g_feed_velocity.bb_w / 2)
+        s += 20;
+
+    s += c.draws_frame > 50 ? 50 : c.draws_frame;
+    if (c.saw_with_depth) s += 35;
+    // Penalize unnamed RGBA full-res with little draw evidence (wrong ME pick pattern).
+    if (FeedVelocityFmtIsRgba16(c.fmt) && !c.name_hit && c.draws_total < 30)
+        s -= 40;
+    if (s < 0) s = 0;
+    c.score = s;
+}
+
+static void FeedVelocityBeginFrame(UINT bb_w, UINT bb_h)
+{
+    g_feed_velocity.bb_w = bb_w;
+    g_feed_velocity.bb_h = bb_h;
+    ++g_feed_velocity.frame_id;
+    // draws_frame is cleared AFTER acquire — FeedFrame11 runs after the game's draws.
+    g_feed_velocity.bound_ok = false;
+    g_feed_velocity.scale_override = false;
+    g_feed_velocity.apply_scale_x = g_feed_velocity.apply_scale_y = 1.0f;
+}
+
+static void FeedVelocityAfterAcquire()
+{
+    for (int i = 0; i < g_feed_velocity.cand_count; ++i)
+        g_feed_velocity.cands[i].draws_frame = 0;
+}
+
+// --- ReShade event hooks ---
+
+static void FeedVelocityOnBindRTs(reshade::api::command_list *cmd_list, uint32_t count,
+                                  const reshade::api::resource_view *rtvs, reshade::api::resource_view dsv)
+{
+    g_feed_velocity.bound_rt_count = 0;
+    g_feed_velocity.bound_has_dsv = dsv.handle != 0;
+    if (cmd_list == nullptr || g_feed_velocity_cfg.enabled == 0) return;
+    reshade::api::device *dev = cmd_list->get_device();
+    if (dev == nullptr || dev->get_api() != reshade::api::device_api::d3d11) return;
+    const uint32_t n = count > 8 ? 8 : count;
+    for (uint32_t i = 0; i < n; ++i)
+    {
+        if (rtvs[i].handle == 0) continue;
+        const reshade::api::resource res = dev->get_resource_from_view(rtvs[i]);
+        if (res.handle == 0) continue;
+        g_feed_velocity.bound_rt[g_feed_velocity.bound_rt_count++] = res.handle;
+        FeedVelocityUpsert(dev, res);
+    }
+}
+
+static bool FeedVelocityOnDraw(reshade::api::command_list *cmd_list)
+{
+    if (g_feed_velocity_cfg.enabled == 0 || g_feed_velocity.bound_rt_count == 0) return false;
+    if (cmd_list == nullptr) return false;
+    reshade::api::device *dev = cmd_list->get_device();
+    if (dev == nullptr || dev->get_api() != reshade::api::device_api::d3d11) return false;
+    for (uint32_t i = 0; i < g_feed_velocity.bound_rt_count; ++i)
+    {
+        reshade::api::resource res = { g_feed_velocity.bound_rt[i] };
+        FeedVelocityUpsert(dev, res);
+        const int idx = FeedVelocityFindCand(res.handle);
+        if (idx < 0) continue;
+        FeedVelocityCand &c = g_feed_velocity.cands[idx];
+        ++c.draws_frame;
+        ++c.draws_total;
+        if (g_feed_velocity.bound_has_dsv) c.saw_with_depth = true;
+        FeedVelocityRescore(c);
+    }
+    return false; // never skip draws
+}
+
+static void FeedVelocityOnInitResource(reshade::api::device *device,
+                                       const reshade::api::resource_desc &desc,
+                                       reshade::api::resource resource)
+{
+    if (device == nullptr || resource.handle == 0) return;
+    if (device->get_api() != reshade::api::device_api::d3d11) return;
+    if (desc.type != reshade::api::resource_type::texture_2d) return;
+    if (!FeedVelocityFmtCandidate(desc.texture.format)) return;
+    FeedVelocityUpsert(device, resource);
+    const int idx = FeedVelocityFindCand(resource.handle);
+    if (idx >= 0) FeedVelocityRescore(g_feed_velocity.cands[idx]);
+}
+
+static void FeedVelocityOnDestroyResource(reshade::api::resource resource)
+{
+    if (resource.handle == 0) return;
+    for (int i = 0; i < g_feed_velocity.cand_count; ++i)
+    {
+        if (g_feed_velocity.cands[i].handle != resource.handle) continue;
+        g_feed_velocity.cands[i] = g_feed_velocity.cands[g_feed_velocity.cand_count - 1];
+        --g_feed_velocity.cand_count;
+        if (g_feed_velocity.chosen_cand == i) g_feed_velocity.chosen_cand = -1;
+        else if (g_feed_velocity.chosen_cand == g_feed_velocity.cand_count)
+            g_feed_velocity.chosen_cand = i;
+        return;
+    }
+}
+
+static void FeedVelocityClearCands()
+{
+    g_feed_velocity.cand_count = 0;
+    g_feed_velocity.chosen_cand = -1;
+    g_feed_velocity.detected = false;
+    g_feed_velocity.var = {};
+    g_feed_velocity.overlay_line[0] = '\0';
+    Log("[feed] velocity: candidate list cleared (rescan)");
+}
+
+static int FeedVelocityAutoPick(UINT expect_w, UINT expect_h)
+{
+    int best = -1, best_score = -1;
+    for (int i = 0; i < g_feed_velocity.cand_count; ++i)
+    {
+        FeedVelocityCand &c = g_feed_velocity.cands[i];
+        FeedVelocityRescore(c);
+        // Prefer RG full-res with draws; allow half-res / RGBA only with name hit or strong evidence.
+        const bool full = (c.width == expect_w && c.height == expect_h);
+        const bool half = (c.width * 2 == expect_w && c.height * 2 == expect_h);
+        const bool rg = FeedVelocityFmtIsRg(c.fmt);
+        if (!full && !half && !c.name_hit) continue;
+        if (!rg && !c.name_hit)
+        {
+            // Unnamed RGBA: require depth co-bind + enough draws, else skip (wrong ME latch).
+            if (!c.saw_with_depth || c.draws_total < 40) continue;
+        }
+        if (c.score > best_score) { best_score = c.score; best = i; }
+    }
+    return best;
+}
+
+// Periodic effect-name scan (still useful when games expose MV via ReShade).
+static void FeedVelocityScanEffects(reshade::api::effect_runtime *rt)
+{
+    if (rt == nullptr) return;
+    rt->enumerate_texture_variables(nullptr,
+        [](reshade::api::effect_runtime *runtime, reshade::api::effect_texture_variable var, void *)
+        {
+            char name[256] = {};
+            runtime->get_texture_variable_name(var, name);
+            if (!FeedVelocityNameHit(name)) return;
+            g_feed_velocity.var = var;
+            _snprintf_s(g_feed_velocity.name, sizeof(g_feed_velocity.name), _TRUNCATE, "%s", name);
+            g_feed_velocity.detected = true;
+            Log("[feed] velocity: effect texture \"%s\"", name);
+        }, nullptr);
+}
+
+static void FeedVelocityTryBind(reshade::api::effect_runtime *rt, UINT expect_w, UINT expect_h)
+{
+    if (g_feed_velocity_cfg.enabled == 0) return;
+    FeedVelocityScanEffects(rt);
+    if (g_feed_velocity_cfg.cand >= 0 && g_feed_velocity_cfg.cand < g_feed_velocity.cand_count)
+        g_feed_velocity.chosen_cand = g_feed_velocity_cfg.cand;
+    else
+        g_feed_velocity.chosen_cand = FeedVelocityAutoPick(expect_w, expect_h);
+
+    g_feed_velocity.detected = g_feed_velocity.cand_count > 0 || g_feed_velocity.var.handle != 0;
+    if (g_feed_velocity.chosen_cand >= 0)
+    {
+        const FeedVelocityCand &c = g_feed_velocity.cands[g_feed_velocity.chosen_cand];
+        _snprintf_s(g_feed_velocity.overlay_line, sizeof(g_feed_velocity.overlay_line), _TRUNCATE,
+                    "auto/pick #%d %s %ux%u score=%d draws=%d",
+                    g_feed_velocity.chosen_cand, FeedVelocityFmtLabel(c.fmt),
+                    c.width, c.height, c.score, c.draws_total);
+    }
+    else
+        _snprintf_s(g_feed_velocity.overlay_line, sizeof(g_feed_velocity.overlay_line), _TRUNCATE,
+                    "%d float RT candidate(s) — pick one or enable Motion Blur in-game",
+                    g_feed_velocity.cand_count);
+}
+
+static void FeedVelocityComputeScale(FeedVelocityDecode mode, UINT src_w, UINT src_h,
+                                     UINT dst_w, UINT dst_h, float user_scale,
+                                     float *ox, float *oy)
+{
+    const float ux = user_scale > 0.f ? user_scale : 1.f;
+    float sx = ux, sy = ux;
+    switch (mode)
+    {
+    case FeedVelDecode_DeltaUV:
+        sx = ux * (float)dst_w;
+        sy = ux * (float)dst_h;
+        break;
+    case FeedVelDecode_UEPacked:
+        // Heuristic: packed [-1,1]-ish → pixel deltas
+        sx = ux * (float)dst_w * 0.5f;
+        sy = ux * (float)dst_h * 0.5f;
+        break;
+    case FeedVelDecode_RawPixels:
+        sx = ux; sy = ux;
+        if (src_w * 2 == dst_w && src_h * 2 == dst_h)
+        { sx *= 2.f; sy *= 2.f; } // half-res vectors in pixels of the half buffer
+        break;
+    case FeedVelDecode_Auto:
+    default:
+        // Prefer RawPixels; if half-res source, double.
+        sx = ux; sy = ux;
+        if (src_w * 2 == dst_w && src_h * 2 == dst_h) { sx *= 2.f; sy *= 2.f; }
+        break;
+    }
+    *ox = sx; *oy = sy;
+}
+
+// Returns AddRef'd RG16F full-res texture for DLSS, or nullptr.
+static ID3D11Texture2D *FeedVelocityAcquireMv(reshade::api::effect_runtime *rt,
+                                               reshade::api::device *dev_api,
+                                               ID3D11Device *dev11,
+                                               ID3D11DeviceContext *ctx,
+                                               UINT expect_w, UINT expect_h)
+{
+    g_feed_velocity.bound_ok = false;
+    g_feed_velocity.bound_src[0] = '\0';
+    g_feed_velocity.scale_override = false;
+    if (g_feed_velocity_cfg.enabled == 0 || dev11 == nullptr || ctx == nullptr)
+        return nullptr;
+
+    ID3D11Texture2D *src = nullptr;
+    UINT src_w = 0, src_h = 0;
+    const char *label = "?";
+    const char *src_tag = "?";
+
+    // 1) ReShade effect texture
+    if (rt != nullptr && dev_api != nullptr && g_feed_velocity.var.handle != 0)
+    {
+        reshade::api::resource_view srv = {}, srgb = {};
+        rt->get_texture_binding(g_feed_velocity.var, &srv, &srgb);
+        if (srv.handle != 0)
+        {
+            const reshade::api::resource res = dev_api->get_resource_from_view(srv);
+            if (res.handle != 0)
+            {
+                auto *raw = reinterpret_cast<ID3D11Resource *>(res.handle);
+                if (SUCCEEDED(raw->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(&src))) && src)
+                {
+                    D3D11_TEXTURE2D_DESC d = {};
+                    src->GetDesc(&d);
+                    src_w = d.Width; src_h = d.Height;
+                    label = g_feed_velocity.name;
+                    src_tag = "effect";
+                }
+            }
+        }
+    }
+
+    // 2) Hunted RT candidate
+    if (src == nullptr)
+    {
+        int pick = g_feed_velocity_cfg.cand;
+        if (pick < 0 || pick >= g_feed_velocity.cand_count)
+            pick = g_feed_velocity.chosen_cand;
+        if (pick < 0 || pick >= g_feed_velocity.cand_count)
+            pick = FeedVelocityAutoPick(expect_w, expect_h);
+        if (pick >= 0 && pick < g_feed_velocity.cand_count)
+        {
+            g_feed_velocity.chosen_cand = pick;
+            const FeedVelocityCand &c = g_feed_velocity.cands[pick];
+            auto *raw = reinterpret_cast<ID3D11Resource *>(c.handle);
+            if (raw && SUCCEEDED(raw->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(&src))) && src)
+            {
+                src_w = c.width; src_h = c.height;
+                label = c.name;
+                src_tag = "hunt";
+            }
+        }
+    }
+
+    if (src == nullptr) return nullptr;
+
+    D3D11_TEXTURE2D_DESC sd = {};
+    src->GetDesc(&sd);
+    const bool size_ok = (sd.Width == expect_w && sd.Height == expect_h) ||
+                         (sd.Width * 2 == expect_w && sd.Height * 2 == expect_h);
+    const bool fmt_ok = sd.Format == DXGI_FORMAT_R16G16_FLOAT ||
+                        sd.Format == DXGI_FORMAT_R16G16_TYPELESS ||
+                        sd.Format == DXGI_FORMAT_R32G32_FLOAT ||
+                        sd.Format == DXGI_FORMAT_R32G32_TYPELESS ||
+                        sd.Format == DXGI_FORMAT_R16G16B16A16_FLOAT ||
+                        sd.Format == DXGI_FORMAT_R16G16B16A16_TYPELESS;
+    if (!size_ok || !fmt_ok)
+    {
+        src->Release();
+        return nullptr;
+    }
+
+    if (!FeedVelocityEnsureOut(dev11, expect_w, expect_h))
+    {
+        src->Release();
+        return nullptr;
+    }
+
+    DXGI_FORMAT srv_fmt = DXGI_FORMAT_R16G16_FLOAT;
+    if (sd.Format == DXGI_FORMAT_R16G16B16A16_FLOAT || sd.Format == DXGI_FORMAT_R16G16B16A16_TYPELESS)
+        srv_fmt = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    else if (sd.Format == DXGI_FORMAT_R32G32_FLOAT || sd.Format == DXGI_FORMAT_R32G32_TYPELESS)
+        srv_fmt = DXGI_FORMAT_R32G32_FLOAT;
+    else if (sd.Format == DXGI_FORMAT_R16G16_FLOAT || sd.Format == DXGI_FORMAT_R16G16_TYPELESS)
+        srv_fmt = DXGI_FORMAT_R16G16_FLOAT;
+    else
+    {
+        src->Release();
+        return nullptr;
+    }
+
+    const bool same_rg16 =
+        sd.Width == expect_w && sd.Height == expect_h &&
+        (sd.Format == DXGI_FORMAT_R16G16_FLOAT || sd.Format == DXGI_FORMAT_R16G16_TYPELESS);
+
+    if (same_rg16)
+        ctx->CopyResource(g_feed_velocity.out_tex, src);
+    else if (!FeedVelocityBlitSrc(dev11, ctx, src, srv_fmt))
+    {
+        static bool said = false;
+        if (!said)
+        {
+            said = true;
+            Log("[feed] velocity: blit failed for %ux%u fmt=%d — falling back to OFA/Lumenite",
+                sd.Width, sd.Height, (int)sd.Format);
+        }
+        src->Release();
+        return nullptr;
+    }
+
+    src->Release();
+
+    FeedVelocityDecode mode = (FeedVelocityDecode)g_feed_velocity_cfg.decode;
+    FeedVelocityComputeScale(mode, sd.Width, sd.Height, expect_w, expect_h,
+                             g_feed_velocity_cfg.scale,
+                             &g_feed_velocity.apply_scale_x, &g_feed_velocity.apply_scale_y);
+    g_feed_velocity.scale_override = true;
+
+    g_feed_velocity.bound_ok = true;
+    g_feed_velocity.last_w = (int)expect_w;
+    g_feed_velocity.last_h = (int)expect_h;
+    _snprintf_s(g_feed_velocity.bound_src, sizeof(g_feed_velocity.bound_src), _TRUNCATE, "%s", src_tag);
+    _snprintf_s(g_feed_velocity.name, sizeof(g_feed_velocity.name), _TRUNCATE, "%s", label);
+    static bool said_ok = false;
+    if (!said_ok)
+    {
+        said_ok = true;
+        Log("[feed] motion vectors: ENGINE VELOCITY \"%s\" via %s (%ux%u←%ux%u) decode=%d scale=%.2f,%.2f",
+            g_feed_velocity.name, src_tag, expect_w, expect_h, sd.Width, sd.Height,
+            g_feed_velocity_cfg.decode, g_feed_velocity.apply_scale_x, g_feed_velocity.apply_scale_y);
+    }
+
+    g_feed_velocity.out_tex->AddRef();
+    return g_feed_velocity.out_tex;
+}


### PR DESCRIPTION
## Summary
- Companion to installer/UI work on oneclick — **no** bundled patched Feeder binary; Feeder changes belong here.
- Companion oneclick PRs (split after closed packaging review of #55):
  - https://github.com/faisalkindi/DLSS5oneclick/pull/58 — Settings / offline Feeder cfg / install defaults
  - https://github.com/faisalkindi/DLSS5oneclick/pull/57 — Feeder perf jsonl → expected FPS
  - https://github.com/faisalkindi/DLSS5oneclick/pull/59 — Per-game overrides + Shipping-exe Install
- Based on `v0.14.0-beta.5` (`cc68576`); `FEED_VERSION` / `version.rc` left untouched at 0.14.0-beta.5.
- FX: raise `DLSS5_Mask` from low provider confidence and appearance / lighting / detail residuals (object ghosting).
- Adapt + LightStab: scene-adaptive history reset and optional post-DLSS lighting dampener.
- OFA + engine velocity: stronger MV sources on D3D11 (`d3dcompiler.lib` added to `build.bat` for OFA).
- Quality presets + Optimize autoprofile (telemetry, not screenshot CV) + `dlss5-perf.jsonl` for oneclick history + extended `[diag]` overlay.

## Build
- `build.bat` → `build\dlss5-feed.addon64` (needs MSVC + `d3dcompiler.lib` for Optical Flow).

## Notes
- Net additions on tip; no mass deletion of 0.14 paths.
- Happy to split follow-ups if you prefer smaller PRs.

## Test plan
- [ ] `build.bat` produces `build\dlss5-feed.addon64`
- [ ] Overlay shows Quality / Optimize / History reset / OFA / velocity controls
- [ ] D3D11 game: velocity or OFA can replace Lumenite MV; adapt reset status updates
- [ ] `dlss5-perf.jsonl` appears next to the add-on after a short run